### PR TITLE
CI: follow branching strategy of node

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -74,7 +74,7 @@ steps:
     status:
     - failure
     branch:
-    - main
+    - dev
 
 volumes:
 - name: rustup
@@ -86,7 +86,9 @@ volumes:
 
 trigger:
   branch:
-  - main
+  - dev
+  - "feat-*"
+  - "release-*"
   event:
     include:
     - pull_request


### PR DESCRIPTION
Changes:
- Run CI on dev, feat-*, release-* branches

Ticket: https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/449