### PR TITLE
Fix CI issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ mode cannot be changed once the contract has been installed. The mode is set by 
 
 #### Modality Conflicts
 
-The currently implemented modalities have no conflicting behavior.
+The implemented modalities have no conflicting behavior.
 
 
 ### Usage
@@ -95,7 +95,7 @@ The following are the required runtime arguments that must be passed to the inst
 
 * `"collection_name":` The name of the NFT collection, passed in as a `String`. This parameter is required and cannot be changed post installation.
 * `"collection_symbol"`: The symbol representing a given NFT collection, passed in as a `String`. This parameter is required and cannot be changed post installation.
-* `"total_token_supply"`: The total number of NFTs that a specific instance of a contract will mint passed in as a `U512` value. This parameter is required and cannot be changed post installation.
+* `"total_token_supply"`: The total number of NFTs that a specific instance of a contract will mint passed in as a `U64` value. This parameter is required and cannot be changed post installation. 
 * `"ownership_mode"`: The [`OwnershipMode`](#ownership) modality that dictates the ownership behavior of the NFT contract. This argument is passed in as a `u8` value and is required at the time of installation.
 * `"nft_kind"`: The [`NFTKind`](#nftkind) modality that specifies the off-chain items represented by the on-chain NFT data. This argument is passed in as a `u8` value and is required at the time of installation.
 * `"json_schema"`: The JSON schema for the NFT tokens that will be minted by the NFT contract passed in as a `String`. This parameter is required and cannot be changed post installation.

--- a/client/mint_session/src/main.rs
+++ b/client/mint_session/src/main.rs
@@ -14,7 +14,6 @@ use casper_types::{runtime_args, ContractHash, Key, RuntimeArgs};
 const ENTRY_POINT_MINT: &str = "mint";
 
 const ARG_NFT_CONTRACT_HASH: &str = "nft_contract_hash";
-const ARG_KEY_NAME: &str = "key_name";
 const ARG_TOKEN_OWNER: &str = "token_owner";
 const ARG_TOKEN_META_DATA: &str = "token_meta_data";
 const ARG_TOKEN_URI: &str = "token_uri";

--- a/contract/src/main.rs
+++ b/contract/src/main.rs
@@ -345,7 +345,7 @@ pub extern "C" fn mint() {
     let collection_name: String = get_stored_value_with_user_errors(
         COLLECTION_NAME,
         NFTCoreError::MissingCollectionName,
-        NFTCoreError::InvalidCollectionName
+        NFTCoreError::InvalidCollectionName,
     );
 
     let receipt = CLValue::from_t((owned_tokens_actual_key, collection_name))
@@ -845,7 +845,7 @@ fn install_nft_contract() -> (ContractHash, ContractVersion) {
             vec![
                 Parameter::new(ARG_COLLECTION_NAME, CLType::String),
                 Parameter::new(ARG_COLLECTION_SYMBOL, CLType::String),
-                Parameter::new(ARG_TOTAL_TOKEN_SUPPLY, CLType::U256),
+                Parameter::new(ARG_TOTAL_TOKEN_SUPPLY, CLType::U64),
                 Parameter::new(ARG_ALLOW_MINTING, CLType::Bool),
                 Parameter::new(ARG_MINTING_MODE, CLType::U8),
                 Parameter::new(ARG_OWNERSHIP_MODE, CLType::U8),

--- a/contract/src/utils.rs
+++ b/contract/src/utils.rs
@@ -94,12 +94,6 @@ impl TryFrom<u8> for MintingMode {
 }
 
 #[repr(u8)]
-pub enum NFTIdentifierMode {
-    Ordinal,
-    Hash
-}
-
-#[repr(u8)]
 pub enum NFTKind {
     /// The NFT represents a real-world physical
     /// like a house.

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-casper-engine-test-support = { version = "2.0.3", features = ["test-support"] }
-casper-execution-engine = "1.4.3"
+casper-engine-test-support = { version = "2.2.0", features = ["test-support"] }
+casper-execution-engine = "2.0.0"
 casper-types = "1.4.5"

--- a/tests/src/mint.rs
+++ b/tests/src/mint.rs
@@ -217,9 +217,7 @@ fn mint_should_return_dictionary_key_to_callers_owned_tokens() {
         .with_allowing_minting(Some(true))
         .build();
 
-    builder.exec(install_request)
-        .expect_success()
-        .commit();
+    builder.exec(install_request).expect_success().commit();
 
     let nft_contract_hash: Key = get_nft_contract_hash(&builder).into();
     let mint_session_call = ExecuteRequestBuilder::standard(
@@ -238,7 +236,11 @@ fn mint_should_return_dictionary_key_to_callers_owned_tokens() {
 
     let account = builder.get_expected_account(*DEFAULT_ACCOUNT_ADDR);
 
-    let owned_key_name = format!("{}_{}", get_nft_contract_hash(&builder).to_formatted_string(), NFT_COLLECTION_NAME);
+    let owned_key_name = format!(
+        "{}_{}",
+        get_nft_contract_hash(&builder).to_formatted_string(),
+        NFT_COLLECTION_NAME
+    );
 
     let (_, owned_tokens_key) = account
         .named_keys()


### PR DESCRIPTION
CHANGELOG:

- Change the `total_token_supply` from U256 to U64 as the u64 range should be sufficient for the maximal amount of NFTs a contract would mint
- Fix CI issues that were blocking the pipeline