### PR TITLE
Fix Mint Session argument documentation

### DIFF
--- a/client/mint_session/README.md
+++ b/client/mint_session/README.md
@@ -14,5 +14,4 @@ The `mint_call` session code takes in the following required runtime arguments.
 
 * `nft_contract_hash`: The hash of a given Enhanced NFT contract passed in as a `Key`.
 * `token_owner`: The `Key` of the owner for the NFT to be minted. Note, this argument is ignored in the `Ownership::Minter` mode.
-* `token_metadata`: The metadata describing the NFT to be minted, passed in as a `String`.
-* `token_uri`: The URI for the off-chain resource represented by the NFT to be minted, passed in as a `String`
+* `token_meta_data`: The metadata describing the NFT to be minted, passed in as a `String`.


### PR DESCRIPTION
Removed unused "token_uri" argument, changed "token_metadata" arg to "token_meta_data" as it is in the contract.