### PR TITLE
Check for approved contracts in transfer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ build-contract:
 	cd client/minting_contract && cargo build --release --target wasm32-unknown-unknown
 	cd client/transfer_session && cargo build --release --target wasm32-unknown-unknown
 	wasm-strip contract/target/wasm32-unknown-unknown/release/contract.wasm 2>/dev/null | true
-	wasm-strip entrypoint_session/target/wasm32-unknown-unknown/release/entrypoint_call.wasm 2>/dev/null | true
 	wasm-strip client/mint_session/target/wasm32-unknown-unknown/release/mint_call.wasm 2>/dev/null | true
 	wasm-strip client/balance_of_session/target/wasm32-unknown-unknown/release/balance_of_call.wasm 2>/dev/null | true
 	wasm-strip client/owner_of_session/target/wasm32-unknown-unknown/release/owner_of_call.wasm 2>/dev/null | true

--- a/contract/src/main.rs
+++ b/contract/src/main.rs
@@ -875,8 +875,6 @@ pub extern "C" fn transfer() {
         runtime::revert(NFTCoreError::InvalidOwnershipMode)
     }
 
-    let holder_mode = utils::get_holder_mode().unwrap_or_revert();
-
     let identifier_mode: NFTIdentifierMode = utils::get_stored_value_with_user_errors::<u8>(
         IDENTIFIER_MODE,
         NFTCoreError::MissingIdentifierMode,
@@ -923,8 +921,8 @@ pub extern "C" fn transfer() {
     };
 
     // Revert if caller is not owner and not approved.
-    if caller != token_owner_key && !is_approved && NFTHolderMode::Accounts == holder_mode {
-        runtime::revert(NFTCoreError::InvalidAccount);
+    if caller != token_owner_key && !is_approved {
+        runtime::revert(NFTCoreError::InvalidTokenOwner);
     }
 
     let target_owner_key: Key = utils::get_named_arg_with_user_errors(

--- a/tests/src/transfer.rs
+++ b/tests/src/transfer.rs
@@ -755,8 +755,8 @@ fn should_prevent_transfer_when_caller_is_not_owner() {
 
     assert_expected_error(
         error,
-        1u16,
-        "transfer from another account must raise InvalidAccount",
+        6u16,
+        "transfer from another account must raise InvalidTokenOwner",
     );
 }
 
@@ -807,4 +807,98 @@ fn should_transfer_token_in_hash_identifier_mode() {
     .build();
 
     builder.exec(transfer_request).expect_success().commit();
+}
+
+#[test]
+fn should_not_allow_non_approved_contract_to_transfer() {
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST).commit();
+
+    let minting_contract_install_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        MINTING_CONTRACT_WASM,
+        runtime_args! {},
+    )
+    .build();
+
+    builder
+        .exec(minting_contract_install_request)
+        .expect_success()
+        .commit();
+
+    let minting_contract_hash = get_minting_contract_hash(&builder);
+    let minting_contract_key: Key = minting_contract_hash.into();
+
+    let install_request = InstallerRequestBuilder::new(*DEFAULT_ACCOUNT_ADDR, NFT_CONTRACT_WASM)
+        .with_total_token_supply(100u64)
+        .with_holder_mode(NFTHolderMode::Mixed)
+        .with_ownership_mode(OwnershipMode::Transferable)
+        .build();
+
+    builder.exec(install_request).expect_success().commit();
+
+    let nft_contract_hash = get_nft_contract_hash(&builder);
+    let nft_contract_key: Key = nft_contract_hash.into();
+
+    let mint_session_call = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        MINT_SESSION_WASM,
+        runtime_args! {
+            ARG_NFT_CONTRACT_HASH => nft_contract_key,
+            ARG_TOKEN_OWNER => Key::Account(*DEFAULT_ACCOUNT_ADDR),
+            ARG_TOKEN_META_DATA => TEST_PRETTY_721_META_DATA ,
+        },
+    )
+    .build();
+
+    builder.exec(mint_session_call).expect_success().commit();
+
+    let transfer_runtime_arguments = runtime_args! {
+        ARG_NFT_CONTRACT_HASH => nft_contract_key,
+        ARG_TOKEN_ID => 0u64,
+        ARG_TARGET_KEY => Key::Account(AccountHash::new([7u8;32])),
+        ARG_SOURCE_KEY => Key::Account(*DEFAULT_ACCOUNT_ADDR),
+    };
+
+    let non_approved_transfer_request = ExecuteRequestBuilder::contract_call_by_hash(
+        *DEFAULT_ACCOUNT_ADDR,
+        minting_contract_hash,
+        ENTRY_POINT_TRANSFER,
+        transfer_runtime_arguments.clone(),
+    )
+    .build();
+
+    builder.exec(non_approved_transfer_request).expect_failure();
+
+    let error = builder
+        .get_error()
+        .expect("non approved transfer must have failed");
+
+    assert_expected_error(error, 6u16, "InvalidTokenOwner(6) must be raised");
+
+    let approve_request = ExecuteRequestBuilder::contract_call_by_hash(
+        *DEFAULT_ACCOUNT_ADDR,
+        nft_contract_hash,
+        ENTRY_POINT_APPROVE,
+        runtime_args! {
+            ARG_TOKEN_ID => 0u64,
+            ARG_OPERATOR => minting_contract_key
+        },
+    )
+    .build();
+
+    builder.exec(approve_request).expect_success().commit();
+
+    let approved_transfer_request = ExecuteRequestBuilder::contract_call_by_hash(
+        *DEFAULT_ACCOUNT_ADDR,
+        minting_contract_hash,
+        ENTRY_POINT_TRANSFER,
+        transfer_runtime_arguments,
+    )
+    .build();
+
+    builder
+        .exec(approved_transfer_request)
+        .expect_success()
+        .commit();
 }


### PR DESCRIPTION
CHANGELOG:

- Updated transfer function to ensure that non-approved contracts cannot transfer NFTs
- Added a test to ensure that the check works correctly