### PR TITLE
Fix handling of optional runtime arguments

### DIFF
--- a/contract/src/utils.rs
+++ b/contract/src/utils.rs
@@ -110,12 +110,15 @@ pub(crate) fn get_named_arg_size(name: &str) -> Option<usize> {
     }
 }
 
+// The optional here is literal and does not co-relate to an Option enum type.
+// If the argument has been provided it is accepted, and is then turned into a Some.
+// If the argument is not provided at all, then it is considered as None.
 pub(crate) fn get_optional_named_arg_with_user_errors<T: FromBytes>(
     name: &str,
     invalid: NFTCoreError,
 ) -> Option<T> {
-    match get_named_arg_with_user_errors(name, NFTCoreError::Phantom, invalid) {
-        Ok(val) => val,
+    match get_named_arg_with_user_errors::<T>(name, NFTCoreError::Phantom, invalid) {
+        Ok(val) => Some(val),
         Err(_) => None,
     }
 }

--- a/tests/src/burn.rs
+++ b/tests/src/burn.rs
@@ -420,7 +420,7 @@ fn should_allow_contract_to_burn_token() {
         .with_holder_mode(NFTHolderMode::Contracts)
         .with_whitelist_mode(WhitelistMode::Locked)
         .with_ownership_mode(OwnershipMode::Minter)
-        .with_minting_mode(Some(MintingMode::Installer as u8))
+        .with_minting_mode(MintingMode::Installer as u8)
         .with_contract_whitelist(contract_whitelist)
         .build();
 

--- a/tests/src/mint.rs
+++ b/tests/src/mint.rs
@@ -42,7 +42,7 @@ struct Metadata {
 
 fn setup_nft_contract(
     total_token_supply: Option<u64>,
-    allowing_minting: Option<bool>,
+    allowing_minting: bool,
 ) -> WasmTestBuilder<InMemoryGlobalState> {
     let mut builder = InMemoryWasmTestBuilder::default();
     builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST).commit();
@@ -66,7 +66,7 @@ fn setup_nft_contract(
 
 #[test]
 fn should_disallow_minting_when_allow_minting_is_set_to_false() {
-    let mut builder = setup_nft_contract(Some(2u64), Some(false));
+    let mut builder = setup_nft_contract(Some(2u64), false);
 
     let mint_request = ExecuteRequestBuilder::contract_call_by_name(
         *DEFAULT_ACCOUNT_ADDR,
@@ -226,7 +226,7 @@ fn mint_should_return_dictionary_key_to_callers_owned_tokens() {
     let install_request = InstallerRequestBuilder::new(*DEFAULT_ACCOUNT_ADDR, NFT_CONTRACT_WASM)
         .with_collection_name(NFT_COLLECTION_NAME.to_string())
         .with_total_token_supply(100u64)
-        .with_allowing_minting(Some(true))
+        .with_allowing_minting(true)
         .build();
 
     builder.exec(install_request).expect_success().commit();
@@ -530,7 +530,7 @@ fn should_allow_public_minting_with_flag_set_to_true() {
 
     let install_request = InstallerRequestBuilder::new(*DEFAULT_ACCOUNT_ADDR, NFT_CONTRACT_WASM)
         .with_total_token_supply(100u64)
-        .with_minting_mode(Some(MintingMode::Public as u8))
+        .with_minting_mode(MintingMode::Public as u8)
         .build();
     builder.exec(install_request).expect_success().commit();
 
@@ -605,7 +605,7 @@ fn should_disallow_public_minting_with_flag_set_to_false() {
 
     let install_request = InstallerRequestBuilder::new(*DEFAULT_ACCOUNT_ADDR, NFT_CONTRACT_WASM)
         .with_total_token_supply(100u64)
-        .with_minting_mode(Some(MintingMode::Installer as u8))
+        .with_minting_mode(MintingMode::Installer as u8)
         .build();
     builder.exec(install_request).expect_success().commit();
 
@@ -666,7 +666,7 @@ fn should_allow_minting_for_different_public_key_with_minting_mode_set_to_public
 
     let install_request = InstallerRequestBuilder::new(*DEFAULT_ACCOUNT_ADDR, NFT_CONTRACT_WASM)
         .with_total_token_supply(100u64)
-        .with_minting_mode(Some(MintingMode::Public as u8))
+        .with_minting_mode(MintingMode::Public as u8)
         .build();
     builder.exec(install_request).expect_success().commit();
 
@@ -852,7 +852,7 @@ fn should_allow_whitelisted_contract_to_mint() {
         .with_holder_mode(NFTHolderMode::Contracts)
         .with_whitelist_mode(WhitelistMode::Locked)
         .with_ownership_mode(OwnershipMode::Minter)
-        .with_minting_mode(Some(MintingMode::Installer as u8))
+        .with_minting_mode(MintingMode::Installer as u8)
         .with_contract_whitelist(contract_whitelist.clone())
         .build();
 
@@ -926,7 +926,7 @@ fn should_disallow_unlisted_contract_from_minting() {
         .with_holder_mode(NFTHolderMode::Contracts)
         .with_whitelist_mode(WhitelistMode::Locked)
         .with_ownership_mode(OwnershipMode::Minter)
-        .with_minting_mode(Some(MintingMode::Installer as u8))
+        .with_minting_mode(MintingMode::Installer as u8)
         .with_contract_whitelist(contract_whitelist)
         .build();
 
@@ -982,7 +982,7 @@ fn should_be_able_to_update_whitelist_for_minting() {
         .with_holder_mode(NFTHolderMode::Contracts)
         .with_whitelist_mode(WhitelistMode::Unlocked)
         .with_ownership_mode(OwnershipMode::Minter)
-        .with_minting_mode(Some(MintingMode::Installer as u8))
+        .with_minting_mode(MintingMode::Installer as u8)
         .with_contract_whitelist(vec![])
         .build();
 
@@ -1026,7 +1026,7 @@ fn should_be_able_to_update_whitelist_for_minting() {
         nft_contract_hash,
         ENTRY_POINT_SET_VARIABLES,
         runtime_args! {
-            ARG_CONTRACT_WHITELIST => Some(vec![minting_contract_hash])
+            ARG_CONTRACT_WHITELIST => vec![minting_contract_hash]
         },
     )
     .build();

--- a/tests/src/set_variables.rs
+++ b/tests/src/set_variables.rs
@@ -24,7 +24,7 @@ fn only_installer_should_be_able_to_toggle_allow_minting() {
         .with_collection_name(NFT_TEST_COLLECTION.to_string())
         .with_collection_symbol(NFT_TEST_SYMBOL.to_string())
         .with_total_token_supply(1u64)
-        .with_allowing_minting(Some(false))
+        .with_allowing_minting(false)
         .build();
 
     builder.exec(install_request).expect_success().commit();

--- a/tests/src/transfer.rs
+++ b/tests/src/transfer.rs
@@ -611,7 +611,7 @@ fn should_transfer_between_contract_to_account() {
         .with_holder_mode(NFTHolderMode::Contracts)
         .with_whitelist_mode(WhitelistMode::Locked)
         .with_ownership_mode(OwnershipMode::Transferable)
-        .with_minting_mode(Some(MintingMode::Installer as u8))
+        .with_minting_mode(MintingMode::Installer as u8)
         .with_contract_whitelist(contract_whitelist.clone())
         .build();
 

--- a/tests/src/utility/installer_request_builder.rs
+++ b/tests/src/utility/installer_request_builder.rs
@@ -169,19 +169,19 @@ impl InstallerRequestBuilder {
             collection_name: CLValue::from_t("name".to_string()).expect("name is legit CLValue"),
             collection_symbol: CLValue::from_t("SYM").expect("collection_symbol is legit CLValue"),
             total_token_supply: CLValue::from_t(1u64).expect("total_token_supply is legit CLValue"),
-            allow_minting: CLValue::from_t(Some(true)).unwrap(),
-            minting_mode: CLValue::from_t(Some(MintingMode::Installer as u8)).unwrap(),
+            allow_minting: CLValue::from_t(true).unwrap(),
+            minting_mode: CLValue::from_t(MintingMode::Installer as u8).unwrap(),
             ownership_mode: CLValue::from_t(OwnershipMode::Minter as u8).unwrap(),
             nft_kind: CLValue::from_t(NFTKind::Physical as u8).unwrap(),
-            holder_mode: CLValue::from_t(Some(NFTHolderMode::Mixed as u8)).unwrap(),
-            whitelist_mode: CLValue::from_t(Some(WhitelistMode::Unlocked as u8)).unwrap(),
-            contract_whitelist: CLValue::from_t(Some(Vec::<ContractHash>::new())).unwrap(),
+            holder_mode: CLValue::from_t(NFTHolderMode::Mixed as u8).unwrap(),
+            whitelist_mode: CLValue::from_t(WhitelistMode::Unlocked as u8).unwrap(),
+            contract_whitelist: CLValue::from_t(Vec::<ContractHash>::new()).unwrap(),
             json_schema: CLValue::from_t("test".to_string())
                 .expect("test_metadata was created from a concrete value"),
             nft_metadata_kind: CLValue::from_t(NFTMetadataKind::NFT721 as u8).unwrap(),
             identifier_mode: CLValue::from_t(NFTIdentifierMode::Ordinal as u8).unwrap(),
             metadata_mutability: CLValue::from_t(MetadataMutability::Mutable as u8).unwrap(),
-            burn_mode: CLValue::from_t(Some(BurnMode::Burnable as u8)).unwrap(),
+            burn_mode: CLValue::from_t(BurnMode::Burnable as u8).unwrap(),
         }
     }
 
@@ -229,13 +229,13 @@ impl InstallerRequestBuilder {
     }
 
     // Why Option here? The None case should be taken care of when running default
-    pub(crate) fn with_allowing_minting(mut self, allow_minting: Option<bool>) -> Self {
+    pub(crate) fn with_allowing_minting(mut self, allow_minting: bool) -> Self {
         self.allow_minting =
             CLValue::from_t(allow_minting).expect("allow minting is legit CLValue");
         self
     }
 
-    pub(crate) fn with_minting_mode(mut self, minting_mode: Option<u8>) -> Self {
+    pub(crate) fn with_minting_mode(mut self, minting_mode: u8) -> Self {
         self.minting_mode = CLValue::from_t(minting_mode).expect("public minting is legit CLValue");
         self
     }
@@ -246,17 +246,17 @@ impl InstallerRequestBuilder {
     }
 
     pub(crate) fn with_holder_mode(mut self, holder_mode: NFTHolderMode) -> Self {
-        self.holder_mode = CLValue::from_t(Some(holder_mode as u8)).unwrap();
+        self.holder_mode = CLValue::from_t(holder_mode as u8).unwrap();
         self
     }
 
     pub(crate) fn with_whitelist_mode(mut self, whitelist_mode: WhitelistMode) -> Self {
-        self.whitelist_mode = CLValue::from_t(Some(whitelist_mode as u8)).unwrap();
+        self.whitelist_mode = CLValue::from_t(whitelist_mode as u8).unwrap();
         self
     }
 
     pub(crate) fn with_contract_whitelist(mut self, contract_whitelist: Vec<ContractHash>) -> Self {
-        self.contract_whitelist = CLValue::from_t(Some(contract_whitelist)).unwrap();
+        self.contract_whitelist = CLValue::from_t(contract_whitelist).unwrap();
         self
     }
 
@@ -284,7 +284,7 @@ impl InstallerRequestBuilder {
     }
 
     pub(crate) fn with_burn_mode(mut self, burn_mode: BurnMode) -> Self {
-        self.burn_mode = CLValue::from_t(Some(burn_mode as u8)).unwrap();
+        self.burn_mode = CLValue::from_t(burn_mode as u8).unwrap();
         self
     }
 


### PR DESCRIPTION
CHANGELOG:

- Fixed a bug which incorrectly handled `optional` runtime arguments causing them to be conflated with the rust Option type
