### PR TITLE
Alter example commands provided in README for multi-line execution. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,8 +279,15 @@ The following are the optional parameters that can be passed in at the time of i
 
 The following is an example of deploying the installation of the NFT contract via the Rust Casper command client.
 
-```rust
-casper-client put-deploy -n http://localhost:11101/rpc --chain-name "casper-net-1" --payment-amount 500000000000 -k ~/casper/casper-node/utils/nctl/assets/net-1/nodes/node-1/keys/secret_key.pem --session-path ~/casper/enhanced-nft/contract/target/wasm32-unknown-unknown/release/contract.wasm --session-arg "collection_name:string='enhanced-nft-1'" --session-arg "collection_symbol:string='ENFT-1'" --session-arg "total_token_supply:u256='10'" --session-arg "ownership_mode:u8='0'" --session-arg "nft_kind:u8='1'" --session-arg "json_schema:string='nft-schema'" --session-arg "allow_minting:bool='true'" 
+```bash
+casper-client put-deploy -n http://localhost:11101/rpc --chain-name "casper-net-1" --payment-amount 500000000000 -k ~/casper/casper-node/utils/nctl/assets/net-1/nodes/node-1/keys/secret_key.pem --session-path ~/casper/enhanced-nft/contract/target/wasm32-unknown-unknown/release/contract.wasm \
+--session-arg "collection_name:string='enhanced-nft-1'" \
+--session-arg "collection_symbol:string='ENFT-1'" \
+--session-arg "total_token_supply:u256='10'" \
+--session-arg "ownership_mode:u8='0'" \
+--session-arg "nft_kind:u8='1'" \
+--session-arg "json_schema:string='nft-schema'" \
+--session-arg "allow_minting:bool='true'" 
 ```
 
 #### Utility session code
@@ -355,18 +362,16 @@ The session arguments match the available modalities as listed in this [README](
 <summary><b>Casper client command without comments</b></summary>
 
 ```bash
-
-casper-client put-deploy -n http://localhost:11101/rpc --chain-name "casper-net-1" --payment-amount 500000000000 -k ~/casper/casper-node/utils/nctl/assets/net-1/nodes/node-1/keys/secret_key.pem --session-path ~/casper/enhanced-nft/contract/target/wasm32-unknown-unknown/release/contract.wasm 
---session-arg "collection_name:string='CEP-78-collection'" 
---session-arg "collection_symbol:string='CEP78'" 
---session-arg "total_token_supply:u64='100'" 
---session-arg "ownership_mode:u8='2'" 
---session-arg "nft_kind:u8='1'" 
---session-arg "nft_metadata_kind:u8='0'" 
---session-arg "json_schema:string=''"
---session-arg "identifier_mode:u8='0'" 
---session-arg "metadata_mutability:u8='0'"
-
+casper-client put-deploy -n http://localhost:11101/rpc --chain-name "casper-net-1" --payment-amount 500000000000 -k ~/casper/casper-node/utils/nctl/assets/net-1/nodes/node-1/keys/secret_key.pem --session-path ~/casper/enhanced-nft/contract/target/wasm32-unknown-unknown/release/contract.wasm \
+--session-arg "collection_name:string='CEP-78-collection'" \
+--session-arg "collection_symbol:string='CEP78'" \
+--session-arg "total_token_supply:u64='100'" \
+--session-arg "ownership_mode:u8='2'" \
+--session-arg "nft_kind:u8='1'" \
+--session-arg "nft_metadata_kind:u8='0'" \
+--session-arg "json_schema:string=''" \
+--session-arg "identifier_mode:u8='0'" \
+--session-arg "metadata_mutability:u8='0'" 
 ```
 
 </details>
@@ -396,9 +401,9 @@ Below is an example of a `casper-client` command that uses the `mint` function o
 
 ```bash
 
-casper-client put-deploy -n http://localhost:11101/rpc --chain-name "casper-net-1" --payment-amount 500000000000 -k ~/casper/casper-node/utils/nctl/assets/net-1/nodes/node-1/keys/secret_key.pem --session-path ~/casper/enhanced-nft/client/mint_session/target/wasm32-unknown-unknown/release/mint_call.wasm
---session-arg "nft_contract_hash:key='hash-206339c3deb8e6146974125bb271eb510795be6f250c21b1bd4b698956669f95'"
---session-arg "token_owner:key='account-hash-e9ff87766a1d2bab2565bfd5799054946200b51b20c3ca7e54a9269e00fe7cfb'"
+casper-client put-deploy -n http://localhost:11101/rpc --chain-name "casper-net-1" --payment-amount 500000000000 -k ~/casper/casper-node/utils/nctl/assets/net-1/nodes/node-1/keys/secret_key.pem --session-path ~/casper/enhanced-nft/client/mint_session/target/wasm32-unknown-unknown/release/mint_call.wasm \
+--session-arg "nft_contract_hash:key='hash-206339c3deb8e6146974125bb271eb510795be6f250c21b1bd4b698956669f95'" \
+--session-arg "token_owner:key='account-hash-e9ff87766a1d2bab2565bfd5799054946200b51b20c3ca7e54a9269e00fe7cfb'"  \
 --session-arg "token_meta_data:string='{\"name\": \"John Doe\",\"token_uri\": \"https:\/\/www.barfoo.com\",\"checksum\": \"940bffb3f2bba35f84313aa26da09ece3ad47045c6a1292c2bbd2df4ab1a55fb\"}'"
 
 ```
@@ -436,11 +441,11 @@ Below is an example of a `casper-client` command that uses the `transfer` functi
 
 ```bash
 
-casper-client put-deploy -n http://localhost:11101/rpc --chain-name "casper-net-1" --payment-amount 500000000000 -k ~/casper/casper-node/utils/nctl/assets/net-1/nodes/node-2/keys/secret_key.pem --session-path ~/casper/enhanced-nft/client/transfer_session/target/wasm32-unknown-unknown/release/transfer_call.wasm 
---session-arg "nft_contract_hash:key='hash-52e78ae3f6c485d036a74f65ebbb8c75fcc7c33fb42eb667fb32aeba72c63fb5'" 
---session-arg "source_key:key='account-hash-e9ff87766a1d2bab2565bfd5799054946200b51b20c3ca7e54a9269e00fe7cfb'" 
---session-arg "target_key:key='account-hash-b4772e7c47e4deca5bd90b7adb2d6e884f2d331825d5419d6cbfb59e17642aab'" 
---session-arg "is_hash_identifier_mode:bool='false'" 
+casper-client put-deploy -n http://localhost:11101/rpc --chain-name "casper-net-1" --payment-amount 500000000000 -k ~/casper/casper-node/utils/nctl/assets/net-1/nodes/node-2/keys/secret_key.pem --session-path ~/casper/enhanced-nft/client/transfer_session/target/wasm32-unknown-unknown/release/transfer_call.wasm \
+--session-arg "nft_contract_hash:key='hash-52e78ae3f6c485d036a74f65ebbb8c75fcc7c33fb42eb667fb32aeba72c63fb5'" \
+--session-arg "source_key:key='account-hash-e9ff87766a1d2bab2565bfd5799054946200b51b20c3ca7e54a9269e00fe7cfb'" \
+--session-arg "target_key:key='account-hash-b4772e7c47e4deca5bd90b7adb2d6e884f2d331825d5419d6cbfb59e17642aab'" \
+--session-arg "is_hash_identifier_mode:bool='false'" \
 --session-arg "token_id:u64='0'"  
 
 ```
@@ -470,9 +475,9 @@ Below is an example of a `casper-client` command that uses the `burn` function t
 
 ```bash
 
-casper-client put-deploy -n http://localhost:11101/rpc --chain-name "casper-net-1" --payment-amount 500000000000 -k ~/casper/casper-node/utils/nctl/assets/net-1/nodes/node-1/keys/secret_key.pem
---session-hash hash-52e78ae3f6c485d036a74f65ebbb8c75fcc7c33fb42eb667fb32aeba72c63fb5
---session-entry-point "burn"
+casper-client put-deploy -n http://localhost:11101/rpc --chain-name "casper-net-1" --payment-amount 500000000000 -k ~/casper/casper-node/utils/nctl/assets/net-1/nodes/node-1/keys/secret_key.pem \
+--session-hash hash-52e78ae3f6c485d036a74f65ebbb8c75fcc7c33fb42eb667fb32aeba72c63fb5 \
+--session-entry-point "burn" \
 --session-arg "token_id:u64='1'"
 
 ```


### PR DESCRIPTION
Adjusted commands contained within the "example command without comments" sections throughout the readme. Adjusted example deploy from rust to bash as the example is a command-line execution, not a block of rust code, and then made the command multi-line.