### PR TITLE
zh-product-387: run on markdown changes

### DIFF
--- a/.github/workflows/ci-cep-78-enhanced-nft.yml
+++ b/.github/workflows/ci-cep-78-enhanced-nft.yml
@@ -6,16 +6,12 @@ on:
       - "dev"
       - "feat-*"
       - "release-*"
-    paths-ignore:
-      - '**.md'
 
   pull_request:
     branches:
       - "dev"
       - "feat-*"
       - "release-*"
-    paths-ignore:
-      - '**.md'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Changes:
- adjusts CI workflow to run even when only markdown changes occurred

Ticket: https://app.zenhub.com/workspaces/engineering-l2-62618a6423afe100128e4656/issues/casperlabs/product/387