### PR TITLE
CI scripts and publish script for JS Client

### DIFF
--- a/.github/workflows/ci-cep-78-client.yml
+++ b/.github/workflows/ci-cep-78-client.yml
@@ -16,8 +16,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
-    env: 
-      working-directory: ./client-js
+    defaults: 
+      run: 
+        working-directory: ./client-js
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-cep-78-client.yml
+++ b/.github/workflows/ci-cep-78-client.yml
@@ -41,7 +41,7 @@ jobs:
         run: npm audit
 
       - name: Lints
-        run: npm run lint:ci
+        run: npm run lint
 
       - name: Test
         run: npm test

--- a/.github/workflows/ci-cep-78-client.yml
+++ b/.github/workflows/ci-cep-78-client.yml
@@ -1,0 +1,44 @@
+name: ci-casper-cep78-js-client
+
+on:
+  push:
+    branches:
+      - "dev"
+      - "feat-*"
+      - "release-*"
+
+  pull_request:
+    branches:
+      - "dev"
+      - "feat-*"
+      - "release-*"
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+        node-version: [18.x]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@5b949b50c3461bbcd5a540b150c368278160234a #v3.4.0
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install
+        run: npm install
+
+      - name: Audits
+        run: npm audit
+
+      - name: Lints
+        run: npm run lint:ci
+
+      - name: Test
+        run: npm test

--- a/.github/workflows/ci-cep-78-client.yml
+++ b/.github/workflows/ci-cep-78-client.yml
@@ -16,9 +16,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
-    defaults: 
-      run: 
-        working-directory: ./client-js
     strategy:
       fail-fast: false
       matrix:
@@ -29,19 +26,38 @@ jobs:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2
 
+      - uses: Swatinem/rust-cache@cb2cf0cc7c5198d3364b9630e2c3d457f160790c #v1.4.0
+
+      - name: Install dependencies
+        run: sudo apt update && sudo apt install -y build-essential wabt
+
+      - name: Setup
+        run: make prepare
+
+      - name: Prepare WASMs 
+        run: make setup-test
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@5b949b50c3461bbcd5a540b150c368278160234a #v3.4.0
+        working-directory: ./client-js
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: Copy WASMs
+        run: ./copy-wasms.sh
+
       - name: Install
+        working-directory: ./client-js
         run: npm install
 
       - name: Audits
+        working-directory: ./client-js
         run: npm audit
 
       - name: Lints
+        working-directory: ./client-js
         run: npm run lint
 
       - name: Test
+        working-directory: ./client-js
         run: npm test

--- a/.github/workflows/ci-cep-78-client.yml
+++ b/.github/workflows/ci-cep-78-client.yml
@@ -15,8 +15,9 @@ on:
 
 jobs:
   build:
-    working-directory: ./client-js
     runs-on: ubuntu-22.04
+    env: 
+      working-directory: ./client-js
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-cep-78-client.yml
+++ b/.github/workflows/ci-cep-78-client.yml
@@ -42,9 +42,17 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: check WASMs
+        working-directory: ./client-js
+        run: ls wasm
+
       - name: Copy WASMs
         working-directory: ./client-js
         run: ./copy-wasms.sh
+
+      - name: check WASMs
+        working-directory: ./client-js
+        run: ls wasm
 
       - name: Install
         working-directory: ./client-js

--- a/.github/workflows/ci-cep-78-client.yml
+++ b/.github/workflows/ci-cep-78-client.yml
@@ -46,10 +46,6 @@ jobs:
         working-directory: ./client-js
         run: ./copy-wasms.sh
 
-      - name: check WASMs
-        working-directory: ./client-js
-        run: ls wasm
-
       - name: Install
         working-directory: ./client-js
         run: npm install

--- a/.github/workflows/ci-cep-78-client.yml
+++ b/.github/workflows/ci-cep-78-client.yml
@@ -42,10 +42,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: check WASMs
-        working-directory: ./client-js
-        run: ls wasm
-
       - name: Copy WASMs
         working-directory: ./client-js
         run: ./copy-wasms.sh

--- a/.github/workflows/ci-cep-78-client.yml
+++ b/.github/workflows/ci-cep-78-client.yml
@@ -39,11 +39,11 @@ jobs:
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@5b949b50c3461bbcd5a540b150c368278160234a #v3.4.0
-        working-directory: ./client-js
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Copy WASMs
+        working-directory: ./client-js
         run: ./copy-wasms.sh
 
       - name: Install

--- a/.github/workflows/ci-cep-78-client.yml
+++ b/.github/workflows/ci-cep-78-client.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   build:
+    working-directory: ./client-js
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false

--- a/.github/workflows/publish-cep-78-client.yml
+++ b/.github/workflows/publish-cep-78-client.yml
@@ -19,7 +19,8 @@ jobs:
         node-version: [18.x]
 
     steps:
-    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2
+    - name: Checkout
+      uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@5b949b50c3461bbcd5a540b150c368278160234a #v3.4.0
       with:

--- a/.github/workflows/publish-cep-78-client.yml
+++ b/.github/workflows/publish-cep-78-client.yml
@@ -10,7 +10,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-22.04
-
+    defaults: 
+      run: 
+        working-directory: ./client-js
     strategy:
       matrix:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/

--- a/.github/workflows/publish-cep-78-client.yml
+++ b/.github/workflows/publish-cep-78-client.yml
@@ -1,0 +1,35 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: publish-casper-cep78-js-client
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-22.04
+
+    strategy:
+      matrix:
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+        node-version: [18.x]
+
+    steps:
+    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@5b949b50c3461bbcd5a540b150c368278160234a #v3.4.0
+      with:
+        node-version: ${{ matrix.node-version }}
+        registry-url: 'https://registry.npmjs.org'
+    - run: npm install
+    - name: Publish to NPM
+      run: npm publish --access public
+      env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - uses: meeDamian/github-release@7ae19492500104f636b3fee4d8103af0fed36c8e #v2.0.3
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        files: casper-js-sdk.v${{ steps.get_version.outputs.version }}.js
+        allow_override: true

--- a/.github/workflows/publish-cep-78-client.yml
+++ b/.github/workflows/publish-cep-78-client.yml
@@ -10,24 +10,40 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-22.04
-    defaults: 
-      run: 
-        working-directory: ./client-js
     strategy:
       matrix:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         node-version: [18.x]
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@5b949b50c3461bbcd5a540b150c368278160234a #v3.4.0
-      with:
-        node-version: ${{ matrix.node-version }}
-        registry-url: 'https://registry.npmjs.org'
-    - run: npm install
-    - name: Publish to NPM
-      run: npm publish --access public
-      env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2
+
+      - uses: Swatinem/rust-cache@cb2cf0cc7c5198d3364b9630e2c3d457f160790c #v1.4.0
+
+      - name: Install dependencies
+        run: sudo apt update && sudo apt install -y build-essential wabt
+
+      - name: Setup
+        run: make prepare
+
+      - name: Prepare WASMs 
+        run: make setup-test
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@5b949b50c3461bbcd5a540b150c368278160234a #v3.4.0
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Copy WASMs
+        working-directory: ./client-js
+        run: ./copy-wasms.sh
+
+      - name: Install
+        working-directory: ./client-js
+        run: npm install
+
+      - name: Publish to NPM
+        run: npm publish --access public
+        env:
+            NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-cep-78-client.yml
+++ b/.github/workflows/publish-cep-78-client.yml
@@ -28,8 +28,3 @@ jobs:
       run: npm publish --access public
       env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-    - uses: meeDamian/github-release@7ae19492500104f636b3fee4d8103af0fed36c8e #v2.0.3
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        files: casper-js-sdk.v${{ steps.get_version.outputs.version }}.js
-        allow_override: true

--- a/client-js/copy-wasms.sh
+++ b/client-js/copy-wasms.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-rm -rf wasm/*
+rm -rf wasm/
+mkdir wasm/
 cp ../tests/wasm/contract.wasm ./wasm
 cp ../tests/wasm/mint_call.wasm ./wasm
 cp ../tests/wasm/balance_of_call.wasm ./wasm

--- a/client-js/copy-wasms.sh
+++ b/client-js/copy-wasms.sh
@@ -7,4 +7,3 @@ cp ../client/owner_of_session/target/wasm32-unknown-unknown/release/owner_of_cal
 cp ../client/get_approved_session/target/wasm32-unknown-unknown/release/get_approved_call.wasm ./wasm
 cp ../client/transfer_session/target/wasm32-unknown-unknown/release/transfer_call.wasm ./wasm
 cp ../client/updated_receipts/target/wasm32-unknown-unknown/release/updated_receipts.wasm ./wasm
-cp ../test-contracts/minting_contract/target/wasm32-unknown-unknown/release/minting_contract.wasm ./wasm

--- a/client-js/copy-wasms.sh
+++ b/client-js/copy-wasms.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-rm -rf wasm/
-mkdir wasm/
+rm -rf wasm
+mkdir ./wasm/
 cp ../tests/wasm/contract.wasm ./wasm
 cp ../tests/wasm/mint_call.wasm ./wasm
 cp ../tests/wasm/balance_of_call.wasm ./wasm

--- a/client-js/copy-wasms.sh
+++ b/client-js/copy-wasms.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 rm -rf wasm/*
-cp ../contract/target/wasm32-unknown-unknown/release/contract.wasm ./wasm
-cp ../client/mint_session/target/wasm32-unknown-unknown/release/mint_call.wasm ./wasm
-cp ../client/balance_of_session/target/wasm32-unknown-unknown/release/balance_of_call.wasm ./wasm
-cp ../client/owner_of_session/target/wasm32-unknown-unknown/release/owner_of_call.wasm ./wasm
-cp ../client/get_approved_session/target/wasm32-unknown-unknown/release/get_approved_call.wasm ./wasm
-cp ../client/transfer_session/target/wasm32-unknown-unknown/release/transfer_call.wasm ./wasm
-cp ../client/updated_receipts/target/wasm32-unknown-unknown/release/updated_receipts.wasm ./wasm
+cp ../tests/wasm/contract.wasm ./wasm
+cp ../tests/wasm/mint_call.wasm ./wasm
+cp ../tests/wasm/balance_of_call.wasm ./wasm
+cp ../tests/wasm/owner_of_call.wasm ./wasm
+cp ../tests/wasm/get_approved_call.wasm ./wasm
+cp ../tests/wasm/transfer_call.wasm ./wasm
+cp ../tests/wasm/updated_receipts.wasm ./wasm

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cep78-js-client",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "CEP78 Enhanced NFT JS Client",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
~~Most of the code is taken from [`casper-js-sdk` repo](https://github.com/casper-ecosystem/casper-js-sdk), I'm just not sure how do we want to distinguish releases of `client-js` and `contract` - TBD with @sacherjj @TomVasile @rob-casper @bradjohnl~~

~~Also I see one problem, we will need to bundle WASMs both for tests and for publish - I thought compiled WASMs will be in the repo, if not maybe this actions can be arranged better to reuse the WASMs between triggered actions. I added a [script](https://github.com/casper-ecosystem/cep-78-enhanced-nft/blob/dev/client-js/copy-wasms.sh) to copy the compiled wasms to the `client-js` directory.~~

This PR includes:

- CI actions that runs `audit` & `test` & `lint`
- CI actions that runs `npm publish` on release created
- Both CI actions compiles contract and sessions WASMs and copy them to `client-js` directory.