### PR TITLE
Add events based on casper-event-standard crate.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,8 @@ test: setup-test
 	cd tests && cargo test
 
 clippy:
-	cd contract && cargo clippy --all-targets -- -D warnings
+	cd contract && cargo clippy --target wasm32-unknown-unknown --bins -- -D warnings
+	cd contract && cargo clippy --no-default-features --lib -- -D warnings
 	cd tests && cargo clippy --all-targets -- -D warnings
 
 check-lint: clippy

--- a/README.md
+++ b/README.md
@@ -307,6 +307,14 @@ This modality provides three options:
 
 The `MetadataMutability` option of `Mutable` cannot be used in conjunction with `NFTIdentifierMode` modality of `Hash`.
 
+#### EventsMode
+
+The `EventsMode` modality allows the deployers of the contract to decide on schemas for recording events during the operation of the contract where changes to the tokens happen.
+
+0. `NoEvents`: No events will be recorded during the operation, this is the default mode.
+1. `CEP47`: The event schema from the CEP47 contract has been implemented as a possibility.
+2. `CES` : Events will be recorded during the operation of the contract using an event schema in compliance with the Casper Event Schema. Refer to  section [Casper Event Standard](#casper-event-standard) for more information.
+
 ### Usage
 
 #### Installing the contract.
@@ -650,6 +658,30 @@ You can determine the token number by multiplying the `page_number` by the `page
 If the `NFTIdentifierMode` is set to `Ordinal`, this number corresponds directly to the token ID.
 
 If it is set to `Hash`, you will need to reference the `HASH_BY_INDEX` dictionary to determine the mapping of token numbers to token hashes.
+
+## Casper Event Standard
+
+When the `CES` events mode is enabled during contract installation, the operations that make changes on the tokens are recorded in the `__events` dictionary. Such event entries can be observed via a node's Server Side Events stream or querying the dictionary at any time using the RPC interface.
+
+The emitted events are encoded according to the [Casper Event Standard](https://github.com/make-software/casper-event-standard), and the schema can be known by an observer reading the `__events_schema` contract named key.
+
+For this CEP-78 reference implementation in particular, the events schema is the following:
+
+| Event name      | Included values and type                                   |
+|-----------------|----------------------------------------------------------------------|
+| Mint            | recipient (Key), token_id (Any), data (String)                       |
+| Transfer        | owner (Key), operator (Option<Key>), recipient (Key), token_id (Any) |
+| Burn            | owner (Key), token_id (Any)                                          |
+| Approval        | owner (Key), operator (Option<Key>), token_id (Any)                  |
+| ApprovalForAll  | owner (Key), operator (Option<Key>), token_ids (List<Any>)           |
+| MetadataUpdated | token_id (Any), data (String)                                        |
+| Migration       | -                                                                    |
+| VariablesSet    | -                                                                    |
+
+Token identifiers are stored under the `CLType` `Any` and the encoding depends on `NFTIdentifierMode`:.
+
+* `NFTIdentifierMode::Ordinal`: the `token id` is encoded as a byte `0x00` followed by a `u64` number.
+* `NFTIdentifierMode::Hash`: the `token_id` is encoded as a byte `0x01` followed by a `String`.
 
 ## Error Codes
 

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -9,6 +9,7 @@ casper-types = "1.4.5"
 serde = { version = "1", features = ["derive", "alloc"], default-features = false }
 base16 = { version = "0.2", default-features = false, features = ["alloc"] }
 casper-serde-json-wasm = { git = "https://github.com/darthsiroftardis/casper-serde-json-wasm", branch = "casper-no-std"}
+casper-event-standard = "0.1.0"
 
 [[bin]]
 name = "contract"

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -9,7 +9,7 @@ casper-types = "1.4.5"
 serde = { version = "1", features = ["derive", "alloc"], default-features = false }
 base16 = { version = "0.2", default-features = false, features = ["alloc"] }
 casper-serde-json-wasm = { git = "https://github.com/darthsiroftardis/casper-serde-json-wasm", branch = "casper-no-std", optional = true }
-casper-event-standard = "0.1.0"
+casper-event-standard = "0.1.1"
 
 [[bin]]
 name = "contract"

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -4,11 +4,11 @@ version = "1.1.1"
 edition = "2018"
 
 [dependencies]
-casper-contract = {version = "1.4.3", features = ["test-support"]}
+casper-contract = { version = "1.4.3", features = ["test-support"], optional = true }
 casper-types = "1.4.5"
 serde = { version = "1", features = ["derive", "alloc"], default-features = false }
 base16 = { version = "0.2", default-features = false, features = ["alloc"] }
-casper-serde-json-wasm = { git = "https://github.com/darthsiroftardis/casper-serde-json-wasm", branch = "casper-no-std"}
+casper-serde-json-wasm = { git = "https://github.com/darthsiroftardis/casper-serde-json-wasm", branch = "casper-no-std", optional = true }
 casper-event-standard = "0.1.0"
 
 [[bin]]
@@ -22,3 +22,9 @@ test = false
 codegen-units = 1
 lto = true
 
+[features]
+default = ["contract-support"]
+contract-support = [ 
+    "dep:casper-contract",
+    "dep:casper-serde-json-wasm"
+]

--- a/contract/src/events.rs
+++ b/contract/src/events.rs
@@ -4,7 +4,7 @@ use casper_types::Key;
 
 use crate::modalities::TokenIdentifier;
 
-#[derive(Event)]
+#[derive(Event, Debug, PartialEq, Eq)]
 pub struct Mint {
     recipient: Key,
     token_id: TokenIdentifier,
@@ -16,12 +16,12 @@ impl Mint {
         Self {
             recipient,
             token_id,
-            data
+            data,
         }
     }
 }
 
-#[derive(Event)]
+#[derive(Event, Debug, PartialEq, Eq)]
 pub struct Burn {
     owner: Key,
     token_id: TokenIdentifier,
@@ -33,7 +33,7 @@ impl Burn {
     }
 }
 
-#[derive(Event)]
+#[derive(Event, Debug, PartialEq, Eq)]
 pub struct Approval {
     owner: Key,
     operator: Key,
@@ -50,7 +50,7 @@ impl Approval {
     }
 }
 
-#[derive(Event)]
+#[derive(Event, Debug, PartialEq, Eq)]
 pub struct ApprovalForAll {
     owner: Key,
     operator: Option<Key>,
@@ -67,7 +67,7 @@ impl ApprovalForAll {
     }
 }
 
-#[derive(Event)]
+#[derive(Event, Debug, PartialEq, Eq)]
 pub struct Transfer {
     owner: Key,
     operator: Option<Key>,
@@ -91,7 +91,7 @@ impl Transfer {
     }
 }
 
-#[derive(Event)]
+#[derive(Event, Debug, PartialEq, Eq)]
 pub struct MetadataUpdated {
     token_id: TokenIdentifier,
     data: String,
@@ -103,7 +103,7 @@ impl MetadataUpdated {
     }
 }
 
-#[derive(Event)]
+#[derive(Event, Debug, PartialEq, Eq, Default)]
 pub struct VariablesSet {}
 
 impl VariablesSet {
@@ -112,7 +112,7 @@ impl VariablesSet {
     }
 }
 
-#[derive(Event)]
+#[derive(Event, Debug, PartialEq, Eq, Default)]
 pub struct Migration {}
 
 impl Migration {

--- a/contract/src/events.rs
+++ b/contract/src/events.rs
@@ -1,0 +1,122 @@
+use alloc::{string::String, vec::Vec};
+use casper_event_standard::Event;
+use casper_types::Key;
+
+use crate::modalities::TokenIdentifier;
+
+#[derive(Event)]
+pub struct Mint {
+    recipient: Key,
+    token_id: TokenIdentifier,
+    data: String,
+}
+
+impl Mint {
+    pub fn new(recipient: Key, token_id: TokenIdentifier, data: String) -> Self {
+        Self {
+            recipient,
+            token_id,
+            data
+        }
+    }
+}
+
+#[derive(Event)]
+pub struct Burn {
+    owner: Key,
+    token_id: TokenIdentifier,
+}
+
+impl Burn {
+    pub fn new(owner: Key, token_id: TokenIdentifier) -> Self {
+        Self { owner, token_id }
+    }
+}
+
+#[derive(Event)]
+pub struct Approval {
+    owner: Key,
+    operator: Key,
+    token_id: TokenIdentifier,
+}
+
+impl Approval {
+    pub fn new(owner: Key, operator: Key, token_id: TokenIdentifier) -> Self {
+        Self {
+            owner,
+            operator,
+            token_id,
+        }
+    }
+}
+
+#[derive(Event)]
+pub struct ApprovalForAll {
+    owner: Key,
+    operator: Option<Key>,
+    token_ids: Vec<TokenIdentifier>,
+}
+
+impl ApprovalForAll {
+    pub fn new(owner: Key, operator: Option<Key>, token_ids: Vec<TokenIdentifier>) -> Self {
+        Self {
+            owner,
+            operator,
+            token_ids,
+        }
+    }
+}
+
+#[derive(Event)]
+pub struct Transfer {
+    owner: Key,
+    operator: Option<Key>,
+    recipient: Key,
+    token_id: TokenIdentifier,
+}
+
+impl Transfer {
+    pub fn new(
+        owner: Key,
+        operator: Option<Key>,
+        recipient: Key,
+        token_id: TokenIdentifier,
+    ) -> Self {
+        Self {
+            owner,
+            operator,
+            recipient,
+            token_id,
+        }
+    }
+}
+
+#[derive(Event)]
+pub struct MetadataUpdated {
+    token_id: TokenIdentifier,
+    data: String,
+}
+
+impl MetadataUpdated {
+    pub fn new(token_id: TokenIdentifier, data: String) -> Self {
+        Self { token_id, data }
+    }
+}
+
+#[derive(Event)]
+pub struct VariablesSet {}
+
+impl VariablesSet {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[derive(Event)]
+pub struct Migration {}
+
+impl Migration {
+    pub fn new() -> Self {
+        Self {}
+    }
+}

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -1,0 +1,7 @@
+#![no_std]
+
+extern crate alloc;
+
+pub mod error;
+pub mod events;
+pub mod modalities;

--- a/contract/src/main.rs
+++ b/contract/src/main.rs
@@ -580,7 +580,11 @@ pub extern "C" fn mint() {
     storage::write(number_of_minted_tokens_uref, minted_tokens_count + 1u64);
 
     // Emit Mint event.
-    casper_event_standard::emit(Mint::new(token_owner_key, token_identifier.clone(), metadata));
+    casper_event_standard::emit(Mint::new(
+        token_owner_key,
+        token_identifier.clone(),
+        metadata,
+    ));
 
     if let OwnerReverseLookupMode::Complete = utils::get_reporting_mode() {
         if (NFTIdentifierMode::Hash == identifier_mode)

--- a/contract/src/main.rs
+++ b/contract/src/main.rs
@@ -6,6 +6,7 @@ compile_error!("target arch should be wasm32: compile with '--target wasm32-unkn
 
 mod constants;
 mod error;
+mod events;
 mod metadata;
 mod modalities;
 mod utils;
@@ -20,6 +21,9 @@ use alloc::{
     vec::Vec,
 };
 use core::convert::TryInto;
+use events::{
+    Approval, ApprovalForAll, Burn, MetadataUpdated, Migration, Mint, Transfer, VariablesSet,
+};
 
 use casper_types::{
     contracts::NamedKeys, runtime_args, CLType, CLValue, ContractHash, ContractPackageHash,
@@ -348,6 +352,9 @@ pub extern "C" fn init() {
         runtime::put_key(PAGE_LIMIT, storage::new_uref(page_table_width).into());
     }
     runtime::put_key(MIGRATION_FLAG, storage::new_uref(true).into());
+
+    // Initialize events structures.
+    utils::init_events();
 }
 
 // set_variables allows the user to set any variable or any combination of variables simultaneously.
@@ -402,6 +409,9 @@ pub extern "C" fn set_variables() {
             WhitelistMode::Locked => runtime::revert(NFTCoreError::InvalidWhitelistMode),
         }
     }
+
+    // Emit VariablesSet event.
+    casper_event_standard::emit(VariablesSet::new());
 }
 
 // Mints a new token. Minting will fail if allow_minting is set to false.
@@ -539,7 +549,7 @@ pub extern "C" fn mint() {
     utils::upsert_dictionary_value_from_key(
         &metadata::get_metadata_dictionary_name(&metadata_kind),
         &token_identifier.get_dictionary_item_key(),
-        metadata,
+        metadata.clone(),
     );
 
     let owned_tokens_item_key = utils::get_owned_tokens_dictionary_item_key(token_owner_key);
@@ -568,6 +578,9 @@ pub extern "C" fn mint() {
         NFTCoreError::InvalidTotalTokenSupply,
     );
     storage::write(number_of_minted_tokens_uref, minted_tokens_count + 1u64);
+
+    // Emit Mint event.
+    casper_event_standard::emit(Mint::new(token_owner_key, token_identifier.clone(), metadata));
 
     if let OwnerReverseLookupMode::Complete = utils::get_reporting_mode() {
         if (NFTIdentifierMode::Hash == identifier_mode)
@@ -696,6 +709,9 @@ pub extern "C" fn burn() {
         };
 
     utils::upsert_dictionary_value_from_key(TOKEN_COUNTS, &owned_tokens_item_key, updated_balance);
+
+    // Emit Burn event.
+    casper_event_standard::emit(Burn::new(token_owner, token_identifier));
 }
 
 // approve marks a token as approved for transfer by an account
@@ -778,6 +794,9 @@ pub extern "C" fn approve() {
         &token_identifier_dictionary_key,
         Some(operator),
     );
+
+    // Emit Approval event.
+    casper_event_standard::emit(Approval::new(token_owner_key, operator, token_identifier));
 }
 
 // This is an extremely gas intensive operation. DO NOT invoke this
@@ -801,6 +820,8 @@ pub extern "C" fn set_approval_for_all() {
     )
     .unwrap_or_revert();
 
+    let token_owner: Key = utils::get_verified_caller().unwrap_or_revert();
+
     let operator = utils::get_named_arg_with_user_errors::<Key>(
         ARG_OPERATOR,
         NFTCoreError::MissingOperator,
@@ -820,14 +841,17 @@ pub extern "C" fn set_approval_for_all() {
     };
 
     // Depending on approve_all we either approve all or disapprove all.
-    for token_id in owned_tokens {
+    let operator = if approve_all { Some(operator) } else { None };
+    for token_id in &owned_tokens {
         // We assume a burned token cannot be approved
-        if utils::is_token_burned(&token_id) {
+        if utils::is_token_burned(token_id) {
             runtime::revert(NFTCoreError::PreviouslyBurntToken)
         }
-        let operator = if approve_all { Some(operator) } else { None };
         storage::dictionary_put(operator_uref, &token_id.get_dictionary_item_key(), operator);
     }
+
+    // Emit ApprovalForAll event.
+    casper_event_standard::emit(ApprovalForAll::new(token_owner, operator, owned_tokens));
 }
 
 // Transfers token from token_owner to specified account. Transfer will go through if caller is
@@ -975,6 +999,19 @@ pub extern "C" fn transfer() {
         &token_identifier.get_dictionary_item_key(),
         Option::<Key>::None,
     );
+
+    // Emit Transfer event.
+    let operator = if caller == token_owner_key {
+        None
+    } else {
+        Some(caller)
+    };
+    casper_event_standard::emit(Transfer::new(
+        token_owner_key,
+        operator,
+        target_owner_key,
+        token_identifier.clone(),
+    ));
 
     if let OwnerReverseLookupMode::Complete = utils::get_reporting_mode() {
         // Update to_account owned_tokens. Revert if owned_tokens list is not found
@@ -1252,8 +1289,11 @@ pub extern "C" fn set_token_metadata() {
     utils::upsert_dictionary_value_from_key(
         &metadata::get_metadata_dictionary_name(&metadata_kind),
         &token_identifier.get_dictionary_item_key(),
-        updated_metadata,
+        updated_metadata.clone(),
     );
+
+    // Emit MetadataUpdate event.
+    casper_event_standard::emit(MetadataUpdated::new(token_identifier, updated_metadata));
 }
 
 #[no_mangle]
@@ -1340,6 +1380,12 @@ pub extern "C" fn migrate() {
             );
         }
     }
+
+    // Initialize events structures.
+    utils::init_events();
+
+    // Emit Migration event.
+    casper_event_standard::emit(Migration::new());
 }
 
 #[no_mangle]

--- a/contract/src/modalities.rs
+++ b/contract/src/modalities.rs
@@ -1,4 +1,12 @@
-use alloc::string::{String, ToString};
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
+use casper_contract::unwrap_or_revert::UnwrapOrRevert;
+use casper_types::{
+    bytesrepr::{self, FromBytes, ToBytes, U64_SERIALIZED_LENGTH, U8_SERIALIZED_LENGTH},
+    CLTyped,
+};
 
 use core::convert::TryFrom;
 
@@ -174,39 +182,87 @@ impl TryFrom<u8> for MetadataMutability {
 }
 
 #[derive(PartialEq, Eq, Clone)]
-pub(crate) enum TokenIdentifier {
+pub enum TokenIdentifier {
     Index(u64),
     Hash(String),
 }
 
 impl TokenIdentifier {
-    pub(crate) fn new_index(index: u64) -> Self {
+    pub fn new_index(index: u64) -> Self {
         TokenIdentifier::Index(index)
     }
 
-    pub(crate) fn new_hash(hash: String) -> Self {
+    pub fn new_hash(hash: String) -> Self {
         TokenIdentifier::Hash(hash)
     }
 
-    pub(crate) fn get_index(&self) -> Option<u64> {
+    pub fn get_index(&self) -> Option<u64> {
         if let Self::Index(index) = self {
             return Some(*index);
         }
         None
     }
 
-    pub(crate) fn get_hash(self) -> Option<String> {
+    pub fn get_hash(self) -> Option<String> {
         if let Self::Hash(hash) = self {
             return Some(hash);
         }
         None
     }
 
-    pub(crate) fn get_dictionary_item_key(&self) -> String {
+    pub fn get_dictionary_item_key(&self) -> String {
         match self {
             TokenIdentifier::Index(token_index) => token_index.to_string(),
             TokenIdentifier::Hash(hash) => hash.clone(),
         }
+    }
+}
+
+impl ToBytes for TokenIdentifier {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut bytes = Vec::new();
+        match self {
+            TokenIdentifier::Index(index) => {
+                bytes.push(NFTIdentifierMode::Ordinal as u8);
+                bytes.append(&mut index.to_bytes()?);
+            }
+            TokenIdentifier::Hash(string) => {
+                bytes.push(NFTIdentifierMode::Hash as u8);
+                bytes.append(&mut string.to_bytes()?);
+            }
+        };
+        Ok(bytes)
+    }
+
+    fn serialized_length(&self) -> usize {
+        U8_SERIALIZED_LENGTH
+            + match self {
+                TokenIdentifier::Index(_) => U64_SERIALIZED_LENGTH,
+                TokenIdentifier::Hash(string) => string.serialized_length(),
+            }
+    }
+}
+
+impl FromBytes for TokenIdentifier {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (identifier_mode, bytes) = u8::from_bytes(bytes)?;
+        let identifier_mode = NFTIdentifierMode::try_from(identifier_mode).unwrap_or_revert();
+        match identifier_mode {
+            NFTIdentifierMode::Ordinal => {
+                let (index, bytes) = u64::from_bytes(bytes)?;
+                Ok((TokenIdentifier::Index(index), bytes))
+            }
+            NFTIdentifierMode::Hash => {
+                let (string, bytes) = String::from_bytes(bytes)?;
+                Ok((TokenIdentifier::Hash(string), bytes))
+            }
+        }
+    }
+}
+
+impl CLTyped for TokenIdentifier {
+    fn cl_type() -> casper_types::CLType {
+        casper_types::CLType::Any
     }
 }
 

--- a/contract/src/modalities.rs
+++ b/contract/src/modalities.rs
@@ -2,7 +2,7 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
-use casper_contract::unwrap_or_revert::UnwrapOrRevert;
+
 use casper_types::{
     bytesrepr::{self, FromBytes, ToBytes, U64_SERIALIZED_LENGTH, U8_SERIALIZED_LENGTH},
     CLTyped,
@@ -10,7 +10,7 @@ use casper_types::{
 
 use core::convert::TryFrom;
 
-use crate::NFTCoreError;
+use crate::error::NFTCoreError;
 
 #[repr(u8)]
 #[derive(PartialEq, Eq)]
@@ -100,6 +100,7 @@ impl TryFrom<u8> for NFTKind {
 }
 
 #[repr(u8)]
+#[derive(Clone, Copy)]
 pub enum NFTMetadataKind {
     CEP78 = 0,
     NFT721 = 1,
@@ -145,7 +146,7 @@ impl TryFrom<u8> for OwnershipMode {
 }
 
 #[repr(u8)]
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Clone, Copy)]
 pub enum NFTIdentifierMode {
     Ordinal = 0,
     Hash = 1,
@@ -181,7 +182,7 @@ impl TryFrom<u8> for MetadataMutability {
     }
 }
 
-#[derive(PartialEq, Eq, Clone)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub enum TokenIdentifier {
     Index(u64),
     Hash(String),
@@ -246,7 +247,8 @@ impl ToBytes for TokenIdentifier {
 impl FromBytes for TokenIdentifier {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
         let (identifier_mode, bytes) = u8::from_bytes(bytes)?;
-        let identifier_mode = NFTIdentifierMode::try_from(identifier_mode).unwrap_or_revert();
+        let identifier_mode = NFTIdentifierMode::try_from(identifier_mode)
+            .map_err(|_| bytesrepr::Error::Formatting)?;
         match identifier_mode {
             NFTIdentifierMode::Ordinal => {
                 let (index, bytes) = u64::from_bytes(bytes)?;

--- a/contract/src/utils.rs
+++ b/contract/src/utils.rs
@@ -5,6 +5,7 @@ use alloc::{
     vec,
     vec::Vec,
 };
+use casper_event_standard::Schemas;
 use core::{convert::TryInto, mem::MaybeUninit};
 
 use casper_contract::{
@@ -26,6 +27,9 @@ use crate::{
         PAGE_LIMIT, RECEIPT_NAME, REPORTING_MODE,
     },
     error::NFTCoreError,
+    events::{
+        Approval, ApprovalForAll, Burn, MetadataUpdated, Migration, Mint, Transfer, VariablesSet,
+    },
     modalities::{
         NFTHolderMode, NFTIdentifierMode, OwnerReverseLookupMode, OwnershipMode, TokenIdentifier,
     },
@@ -737,4 +741,18 @@ pub(crate) fn get_reporting_mode() -> OwnerReverseLookupMode {
     )
     .try_into()
     .unwrap_or_revert()
+}
+
+// Initializes events-releated named keys and records all event schemas.
+pub fn init_events() {
+    let schemas = Schemas::new()
+        .with::<Mint>()
+        .with::<Burn>()
+        .with::<Approval>()
+        .with::<ApprovalForAll>()
+        .with::<Transfer>()
+        .with::<MetadataUpdated>()
+        .with::<VariablesSet>()
+        .with::<Migration>();
+    casper_event_standard::init(schemas);
 }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -15,4 +15,4 @@ blake2 = { version = "0.9.0", default-features = false }
 base16 = { version = "0.2", default-features = false }
 rand = "0.8.5"
 sha256 = "1.0.3"
-casper-event-standard = "0.1.0"
+casper-event-standard = "0.1.1"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -4,6 +4,7 @@ version = "1.1.1"
 edition = "2018"
 
 [dependencies]
+contract = { path = "../contract", default-features = false }
 casper-engine-test-support = { version = "2.2.0", features = ["test-support"] }
 casper-execution-engine = "2.0.0"
 casper-types = "1.4.5"
@@ -14,3 +15,4 @@ blake2 = { version = "0.9.0", default-features = false }
 base16 = { version = "0.2", default-features = false }
 rand = "0.8.5"
 sha256 = "1.0.3"
+casper-event-standard = "0.1.0"

--- a/tests/src/installer.rs
+++ b/tests/src/installer.rs
@@ -2,7 +2,11 @@ use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
     DEFAULT_RUN_GENESIS_REQUEST,
 };
+use casper_event_standard::Schemas;
 use casper_types::{runtime_args, CLValue, ContractHash, RuntimeArgs};
+use contract::events::{
+    Approval, ApprovalForAll, Burn, MetadataUpdated, Migration, Mint, Transfer, VariablesSet,
+};
 
 use crate::utility::{
     constants::{
@@ -39,7 +43,7 @@ fn should_install_contract() {
         .expect("must have key in named keys");
 
     let query_result: String = support::query_stored_value(
-        &mut builder,
+        &builder,
         *nft_contract_key,
         vec![ARG_COLLECTION_NAME.to_string()],
     );
@@ -51,7 +55,7 @@ fn should_install_contract() {
     );
 
     let query_result: String = support::query_stored_value(
-        &mut builder,
+        &builder,
         *nft_contract_key,
         vec![ARG_COLLECTION_SYMBOL.to_string()],
     );
@@ -63,7 +67,7 @@ fn should_install_contract() {
     );
 
     let query_result: u64 = support::query_stored_value(
-        &mut builder,
+        &builder,
         *nft_contract_key,
         vec![ARG_TOTAL_TOKEN_SUPPLY.to_string()],
     );
@@ -74,7 +78,7 @@ fn should_install_contract() {
     );
 
     let query_result: bool = support::query_stored_value(
-        &mut builder,
+        &builder,
         *nft_contract_key,
         vec![ARG_ALLOW_MINTING.to_string()],
     );
@@ -82,7 +86,7 @@ fn should_install_contract() {
     assert!(query_result, "Allow minting should default to true");
 
     let query_result: u8 = support::query_stored_value(
-        &mut builder,
+        &builder,
         *nft_contract_key,
         vec![ARG_MINTING_MODE.to_string()],
     );
@@ -93,7 +97,7 @@ fn should_install_contract() {
     );
 
     let query_result: u64 = support::query_stored_value(
-        &mut builder,
+        &builder,
         *nft_contract_key,
         vec![NUMBER_OF_MINTED_TOKENS.to_string()],
     );
@@ -102,6 +106,23 @@ fn should_install_contract() {
         query_result, 0u64,
         "number_of_minted_tokens initialized at installation should exist"
     );
+
+    // Expects Schemas to be registerd.
+    let expected_schemas = Schemas::new()
+        .with::<Mint>()
+        .with::<Burn>()
+        .with::<Approval>()
+        .with::<ApprovalForAll>()
+        .with::<Transfer>()
+        .with::<MetadataUpdated>()
+        .with::<VariablesSet>()
+        .with::<Migration>();
+    let actual_schemas: Schemas = support::query_stored_value(
+        &builder,
+        *nft_contract_key,
+        vec![casper_event_standard::EVENTS_SCHEMA.to_string()],
+    );
+    assert_eq!(actual_schemas, expected_schemas, "Schemas mismatch.");
 }
 
 #[test]
@@ -222,7 +243,7 @@ fn should_install_with_contract_holder_mode() {
         .expect("must have key in named keys");
 
     let actual_holder_mode: u8 = support::query_stored_value(
-        &mut builder,
+        &builder,
         *nft_contract_key,
         vec![ARG_HOLDER_MODE.to_string()],
     );
@@ -234,7 +255,7 @@ fn should_install_with_contract_holder_mode() {
     );
 
     let actual_whitelist_mode: u8 = support::query_stored_value(
-        &mut builder,
+        &builder,
         *nft_contract_key,
         vec![ARG_WHITELIST_MODE.to_string()],
     );
@@ -246,7 +267,7 @@ fn should_install_with_contract_holder_mode() {
     );
 
     let actual_contract_whitelist: Vec<ContractHash> = support::query_stored_value(
-        &mut builder,
+        &builder,
         *nft_contract_key,
         vec![ARG_CONTRACT_WHITELIST.to_string()],
     );

--- a/tests/src/set_variables.rs
+++ b/tests/src/set_variables.rs
@@ -3,6 +3,7 @@ use casper_engine_test_support::{
     DEFAULT_RUN_GENESIS_REQUEST,
 };
 use casper_types::{runtime_args, ContractHash, Key, RuntimeArgs};
+use contract::events::VariablesSet;
 
 use crate::utility::{
     constants::{
@@ -31,15 +32,16 @@ fn only_installer_should_be_able_to_toggle_allow_minting() {
     builder.exec(install_request).expect_success().commit();
 
     let account = builder.get_expected_account(*DEFAULT_ACCOUNT_ADDR);
-    let nft_contract_hash = account
+    let nft_contract_key: Key = *account
         .named_keys()
         .get(CONTRACT_NAME)
-        .cloned()
-        .and_then(Key::into_hash)
+        .expect("must have key in named keys");
+
+    let nft_contract_hash = Key::into_hash(nft_contract_key)
         .map(ContractHash::new)
         .expect("failed to find nft contract");
 
-    //Account other than installer account should not be able to change allow_minting
+    // Account other than installer account should not be able to change allow_minting
     // Red test
     let other_user_set_variables_request = ExecuteRequestBuilder::contract_call_by_hash(
         other_user_account,
@@ -72,4 +74,9 @@ fn only_installer_should_be_able_to_toggle_allow_minting() {
         .exec(installer_set_variables_request)
         .expect_success()
         .commit();
+
+    // Expect VariablesSet event.
+    let expected_event = VariablesSet::new();
+    let actual_event: VariablesSet = support::get_event(&builder, &nft_contract_key, 0);
+    assert_eq!(actual_event, expected_event, "Expected VariablesSet event.");
 }

--- a/tests/src/upgrade.rs
+++ b/tests/src/upgrade.rs
@@ -4,6 +4,7 @@ use casper_engine_test_support::{
 };
 use casper_execution_engine::storage::global_state::in_memory::InMemoryGlobalState;
 use casper_types::{account::AccountHash, runtime_args, CLValue, ContractHash, Key, RuntimeArgs};
+use contract::events::Migration;
 
 use crate::utility::{
     constants::{
@@ -140,6 +141,11 @@ fn should_safely_upgrade_in_ordinal_identifier_mode() {
         page
     };
     assert_eq!(actual_page, expected_page);
+
+    // Expect Migration event.
+    let expected_event = Migration::new();
+    let actual_event: Migration = support::get_event(&builder, &nft_contract_key, 0);
+    assert_eq!(actual_event, expected_event, "Expected Migration event.");
 
     let mint_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,

--- a/tests/src/utility/installer_request_builder.rs
+++ b/tests/src/utility/installer_request_builder.rs
@@ -15,6 +15,13 @@ use crate::utility::constants::{
     ARG_WHITELIST_MODE, NFT_TEST_COLLECTION, NFT_TEST_SYMBOL,
 };
 
+// Modalities reexports.
+pub use contract::modalities::{
+    BurnMode, MetadataMutability, MintingMode, NFTHolderMode, NFTIdentifierMode, NFTKind,
+    NFTMetadataKind, NamedKeyConventionMode, OwnerReverseLookupMode, OwnershipMode,
+    TokenIdentifier, WhitelistMode,
+};
+
 pub(crate) static TEST_CUSTOM_METADATA_SCHEMA: Lazy<CustomMetadataSchema> = Lazy::new(|| {
     let mut properties = BTreeMap::new();
     properties.insert(
@@ -50,44 +57,6 @@ pub(crate) static TEST_CUSTOM_UPDATED_METADATA: Lazy<BTreeMap<String, String>> =
     attributes
 });
 
-#[repr(u8)]
-pub enum WhitelistMode {
-    Unlocked = 0,
-    Locked = 1,
-}
-
-#[repr(u8)]
-pub enum NFTHolderMode {
-    Accounts = 0,
-    Contracts = 1,
-    Mixed = 2,
-}
-
-#[repr(u8)]
-pub enum MintingMode {
-    /// The ability to mint NFTs is restricted to the installing account only.
-    Installer = 0,
-    /// The ability to mint NFTs is not restricted.
-    Public = 1,
-}
-
-#[repr(u8)]
-#[derive(Debug)]
-pub enum OwnershipMode {
-    Minter = 0,       // The minter owns it and can never transfer it.
-    Assigned = 1,     // The minter assigns it to an address and can never be transferred.
-    Transferable = 2, // The NFT can be transferred even to an recipient that does not exist.
-}
-
-#[repr(u8)]
-#[derive(Debug)]
-#[allow(dead_code)]
-pub enum NFTKind {
-    Physical = 0,
-    Digital = 1, // The minter assigns it to an address and can never be transferred.
-    Virtual = 2, // The NFT can be transferred even to an recipient that does not exist
-}
-
 #[derive(Serialize, Deserialize, Clone)]
 pub(crate) struct MetadataSchemaProperty {
     name: String,
@@ -105,47 +74,6 @@ struct Metadata {
     name: String,
     symbol: String,
     token_uri: String,
-}
-
-#[repr(u8)]
-#[derive(Copy, Clone)]
-pub enum NFTMetadataKind {
-    CEP78 = 0,
-    NFT721 = 1,
-    Raw = 2,
-    CustomValidated = 3,
-}
-
-#[repr(u8)]
-#[derive(Copy, Clone)]
-pub enum NFTIdentifierMode {
-    Ordinal = 0,
-    Hash = 1,
-}
-
-#[repr(u8)]
-pub enum MetadataMutability {
-    Immutable = 0,
-    Mutable = 1,
-}
-
-#[repr(u8)]
-pub enum BurnMode {
-    Burnable = 0,
-    NonBurnable = 1,
-}
-
-#[repr(u8)]
-pub enum OwnerReverseLookupMode {
-    NoLookUp = 0,
-    Complete = 1,
-}
-
-#[repr(u8)]
-pub enum NamedKeyConventionMode {
-    DerivedFromCollectionName = 0,
-    V1_0Standard = 1,
-    V1_0Custom = 2,
 }
 
 #[derive(Debug)]

--- a/tests/src/utility/support.rs
+++ b/tests/src/utility/support.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use crate::utility::constants::{
     ARG_KEY_NAME, ARG_NFT_CONTRACT_HASH, HASH_KEY_NAME, INDEX_BY_HASH, MINTING_CONTRACT_NAME,
     PAGE_DICTIONARY_PREFIX, PAGE_SIZE,
@@ -20,8 +22,10 @@ use casper_execution_engine::{
     storage::global_state::in_memory::InMemoryGlobalState,
 };
 use casper_types::{
-    account::AccountHash, bytesrepr::FromBytes, ApiError, CLTyped, CLValueError, ContractHash,
-    ContractPackageHash, Key, PublicKey, RuntimeArgs, SecretKey, URef, BLAKE2B_DIGEST_LENGTH,
+    account::AccountHash,
+    bytesrepr::{Bytes, FromBytes},
+    ApiError, CLTyped, CLValueError, ContractHash, ContractPackageHash, Key, PublicKey,
+    RuntimeArgs, SecretKey, URef, BLAKE2B_DIGEST_LENGTH,
 };
 
 pub(crate) fn get_nft_contract_hash(
@@ -141,7 +145,7 @@ pub(crate) fn _get_uref(builder: &WasmTestBuilder<InMemoryGlobalState>, key: &st
 }
 
 pub(crate) fn query_stored_value<T: CLTyped + FromBytes>(
-    builder: &mut InMemoryWasmTestBuilder,
+    builder: &InMemoryWasmTestBuilder,
     base_key: Key,
     path: Vec<String>,
 ) -> T {
@@ -260,4 +264,20 @@ pub(crate) fn get_stored_value_from_global_state<T: CLTyped + FromBytes>(
 
 pub(crate) fn get_receipt_name(nft_receipt: String, page_table_entry: u64) -> String {
     format!("{}_m_{}_p_{}", nft_receipt, PAGE_SIZE, page_table_entry)
+}
+
+pub fn get_event<T: FromBytes + CLTyped + Debug>(
+    builder: &WasmTestBuilder<InMemoryGlobalState>,
+    nft_contract_key: &Key,
+    index: u32,
+) -> T {
+    let bytes: Bytes = get_dictionary_value_from_key(
+        builder,
+        nft_contract_key,
+        casper_event_standard::EVENTS_DICT,
+        &index.to_string(),
+    );
+    let (event, bytes) = T::from_bytes(&bytes).unwrap();
+    assert!(bytes.is_empty());
+    event
 }


### PR DESCRIPTION
The `casper-event-standard` is a library that contracts can import to _emit_ events in a standardized format. The repository is here: https://github.com/make-software/casper-event-standard

In this PR, we have integrated this library into the CEP-78 contract. A dictionary to store the events is created during contract initialization. Then, events are added to the dictionary for every action the contract offers (i.e. Mint, Transfer, Approve, etc...). The events schema is also stored in the contract as a named key to help the observers parse the events' content.
