### PR TITLE
CI: use matrix os on client ci

### DIFF
--- a/.github/workflows/ci-cep-78-client.yml
+++ b/.github/workflows/ci-cep-78-client.yml
@@ -14,7 +14,7 @@ on:
       - "release-*"
 
 jobs:
-  build:
+  client-build:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-cep-78-client.yml
+++ b/.github/workflows/ci-cep-78-client.yml
@@ -15,12 +15,13 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         node-version: [18.x]
+        os: [ubuntu-20.04, ubuntu-22.04]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
changes:
- adds building on both 20.04 and 22.04