### PR TITLE
Set serde-json-wasm as dep

### DIFF
--- a/client/updated_receipts/src/main.rs
+++ b/client/updated_receipts/src/main.rs
@@ -6,17 +6,12 @@ compile_error!("target arch should be wasm32: compile with '--target wasm32-unkn
 
 extern crate alloc;
 
-use alloc::format;
-use alloc::string::String;
-use alloc::vec::Vec;
+use alloc::{string::String, vec::Vec};
 
-use casper_contract::contract_api::runtime;
-use casper_contract::unwrap_or_revert::UnwrapOrRevert;
-use casper_types;
-use casper_types::{ContractPackageHash, Key, runtime_args, RuntimeArgs};
+use casper_contract::{contract_api::runtime, unwrap_or_revert::UnwrapOrRevert};
+use casper_types::{self, runtime_args, ContractPackageHash, Key, RuntimeArgs};
 
 const ENTRY_POINT_UPDATE_RECEIPTS: &str = "updated_receipts";
-const ARG_COLLECTION_NAME: &str = "collection_name";
 const ARG_NFT_PACKAGE_HASH: &str = "nft_package_hash";
 
 #[no_mangle]
@@ -26,18 +21,15 @@ pub extern "C" fn call() {
         .map(ContractPackageHash::new)
         .unwrap_or_revert();
 
-
     // This value represents a list of receipt names and addresses corresponding
     // to the pages marking ownership of NFTs owned by the account.
     let updated_receipt_data = runtime::call_versioned_contract::<Vec<(String, Key)>>(
         nft_package_hash,
         None,
         ENTRY_POINT_UPDATE_RECEIPTS,
-        runtime_args! {}
+        runtime_args! {},
     );
     for (receipt_name, dictionary_address) in updated_receipt_data.into_iter() {
         runtime::put_key(&receipt_name, dictionary_address)
     }
 }
-
-

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -4,7 +4,9 @@ version = "1.1.1"
 edition = "2018"
 
 [dependencies]
-casper-contract = { version = "1.4.3", features = ["test-support"] }
+casper-contract = { version = "1.4.3", features = [
+  "test-support",
+], optional = true }
 casper-types = "1.4.5"
 serde = { version = "1", features = [
   "derive",

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -4,11 +4,17 @@ version = "1.1.1"
 edition = "2018"
 
 [dependencies]
-casper-contract = {version = "1.4.3", features = ["test-support"]}
+casper-contract = { version = "1.4.3", features = ["test-support"] }
 casper-types = "1.4.5"
-serde = { version = "1", features = ["derive", "alloc"], default-features = false }
+serde = { version = "1", features = [
+  "derive",
+  "alloc",
+], default-features = false }
+serde_json = { version = "^1.0.59", default-features = false, features = [
+  "alloc",
+] }
+serde-json-wasm = "0.5.0"
 base16 = { version = "0.2", default-features = false, features = ["alloc"] }
-casper-serde-json-wasm = { git = "https://github.com/darthsiroftardis/casper-serde-json-wasm", branch = "casper-no-std"}
 
 [[bin]]
 name = "contract"
@@ -21,3 +27,6 @@ test = false
 codegen-units = 1
 lto = true
 
+[features]
+default = ["std"]
+std = ["casper-contract/std", "casper-types/std"]

--- a/contract/src/main.rs
+++ b/contract/src/main.rs
@@ -240,7 +240,7 @@ pub extern "C" fn init() {
         if required_or_optional == &Requirement::Required
             || required_or_optional == &Requirement::Optional
         {
-            casper_serde_json_wasm::from_str::<CustomMetadataSchema>(&json_schema)
+            serde_json_wasm::from_str::<CustomMetadataSchema>(&json_schema)
                 .map_err(|_| NFTCoreError::InvalidJsonSchema)
                 .unwrap_or_revert();
         }

--- a/contract/src/metadata.rs
+++ b/contract/src/metadata.rs
@@ -135,7 +135,7 @@ pub(crate) fn get_metadata_schema(kind: &NFTMetadataKind) -> CustomMetadataSchem
                 NFTCoreError::InvalidJsonSchema,
             );
 
-            casper_serde_json_wasm::from_str::<CustomMetadataSchema>(&custom_schema_json)
+            serde_json_wasm::from_str::<CustomMetadataSchema>(&custom_schema_json)
                 .map_err(|_| NFTCoreError::InvalidJsonSchema)
                 .unwrap_or_revert()
         }
@@ -197,7 +197,7 @@ pub(crate) fn validate_metadata(
     let token_schema = get_metadata_schema(metadata_kind);
     match metadata_kind {
         NFTMetadataKind::CEP78 => {
-            let metadata = casper_serde_json_wasm::from_str::<MetadataCEP78>(&token_metadata)
+            let metadata = serde_json_wasm::from_str::<MetadataCEP78>(&token_metadata)
                 .map_err(|_| NFTCoreError::FailedToParseCep99Metadata)?;
 
             if let Some(name_property) = token_schema.properties.get("name") {
@@ -215,11 +215,11 @@ pub(crate) fn validate_metadata(
                     runtime::revert(NFTCoreError::InvalidCEP99Metadata)
                 }
             }
-            casper_serde_json_wasm::to_string_pretty(&metadata)
+            serde_json::to_string_pretty(&metadata)
                 .map_err(|_| NFTCoreError::FailedToJsonifyCEP99Metadata)
         }
         NFTMetadataKind::NFT721 => {
-            let metadata = casper_serde_json_wasm::from_str::<MetadataNFT721>(&token_metadata)
+            let metadata = serde_json_wasm::from_str::<MetadataNFT721>(&token_metadata)
                 .map_err(|_| NFTCoreError::FailedToParse721Metadata)?;
 
             if let Some(name_property) = token_schema.properties.get("name") {
@@ -237,13 +237,13 @@ pub(crate) fn validate_metadata(
                     runtime::revert(NFTCoreError::InvalidNFT721Metadata)
                 }
             }
-            casper_serde_json_wasm::to_string_pretty(&metadata)
+            serde_json::to_string_pretty(&metadata)
                 .map_err(|_| NFTCoreError::FailedToJsonifyNFT721Metadata)
         }
         NFTMetadataKind::Raw => Ok(token_metadata),
         NFTMetadataKind::CustomValidated => {
             let custom_metadata =
-                casper_serde_json_wasm::from_str::<BTreeMap<String, String>>(&token_metadata)
+                serde_json_wasm::from_str::<BTreeMap<String, String>>(&token_metadata)
                     .map(|attributes| CustomMetadata { attributes })
                     .map_err(|_| NFTCoreError::FailedToParseCustomMetadata)?;
 
@@ -253,7 +253,7 @@ pub(crate) fn validate_metadata(
                     runtime::revert(NFTCoreError::InvalidCustomMetadata)
                 }
             }
-            casper_serde_json_wasm::to_string_pretty(&custom_metadata.attributes)
+            serde_json::to_string_pretty(&custom_metadata.attributes)
                 .map_err(|_| NFTCoreError::FailedToJsonifyCustomMetadata)
         }
     }

--- a/test-contracts/mangle_named_keys/src/main.rs
+++ b/test-contracts/mangle_named_keys/src/main.rs
@@ -4,10 +4,7 @@
 #[cfg(not(target_arch = "wasm32"))]
 compile_error!("target arch should be wasm32: compile with '--target wasm32-unknown-unknown'");
 
-use casper_contract::contract_api::{runtime, storage};
-use casper_contract::unwrap_or_revert::UnwrapOrRevert;
-use casper_types::{CLType, ContractHash, ContractVersion, EntryPoint, EntryPointAccess, EntryPoints, EntryPointType, Key, Parameter, runtime_args, RuntimeArgs, URef};
-use casper_types::contracts::NamedKeys;
+use casper_contract::{contract_api::runtime, unwrap_or_revert::UnwrapOrRevert};
 
 const ACCESS_KEY_NAME_1_0_0: &str = "nft_contract_package_access";
 const HASH_KEY_NAME_1_0_0: &str = "nft_contract_package";
@@ -17,7 +14,7 @@ const MANGLED_HASH_KEY_NAME: &str = "mangled_hash_key";
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let access_key =  runtime::get_key(ACCESS_KEY_NAME_1_0_0).unwrap_or_revert();
+    let access_key = runtime::get_key(ACCESS_KEY_NAME_1_0_0).unwrap_or_revert();
     runtime::put_key(MANGLED_ACCESS_KEY_NAME, access_key);
     runtime::remove_key(ACCESS_KEY_NAME_1_0_0);
 
@@ -25,4 +22,3 @@ pub extern "C" fn call() {
     runtime::put_key(MANGLED_HASH_KEY_NAME, package_key);
     runtime::remove_key(HASH_KEY_NAME_1_0_0);
 }
-

--- a/test-contracts/minting_contract/src/main.rs
+++ b/test-contracts/minting_contract/src/main.rs
@@ -6,11 +6,16 @@ compile_error!("target arch should be wasm32: compile with '--target wasm32-unkn
 
 extern crate alloc;
 
-use alloc::{vec, string::{String, ToString}, format};
+use alloc::{
+    string::{String, ToString},
+    vec,
+};
 
 use casper_contract::contract_api::{runtime, storage};
-use casper_types::{CLType, ContractHash, ContractVersion, EntryPoint, EntryPointAccess, EntryPoints, EntryPointType, Key, Parameter, runtime_args, RuntimeArgs, URef};
-use casper_types::contracts::NamedKeys;
+use casper_types::{
+    contracts::NamedKeys, runtime_args, CLType, ContractHash, ContractVersion, EntryPoint,
+    EntryPointAccess, EntryPointType, EntryPoints, Key, Parameter, RuntimeArgs, URef,
+};
 
 const CONTRACT_NAME: &str = "minting_contract_hash";
 const CONTRACT_VERSION: &str = "minting_contract_version";
@@ -32,7 +37,6 @@ const ARG_SOURCE_KEY: &str = "source_key";
 const ARG_TOKEN_ID: &str = "token_id";
 const ARG_REVERSE_LOOKUP: &str = "reverse_lookup";
 
-
 #[no_mangle]
 pub extern "C" fn mint() {
     let nft_contract_hash: ContractHash = runtime::get_named_arg::<Key>(ARG_NFT_CONTRACT_HASH)
@@ -49,18 +53,19 @@ pub extern "C" fn mint() {
             nft_contract_hash,
             ENTRY_POINT_REGISTER_OWNER,
             runtime_args! {
-            ARG_TOKEN_OWNER => token_owner,
-        }
+                ARG_TOKEN_OWNER => token_owner,
+            },
         );
 
-        let (collection_name, owned_tokens_dictionary_key,_token_id_string ) = runtime::call_contract::<(String, Key, String)>(
-            nft_contract_hash,
-            ENTRY_POINT_MINT,
-            runtime_args! {
-            ARG_TOKEN_OWNER => token_owner,
-            ARG_TOKEN_META_DATA => token_metadata,
-        },
-        );
+        let (collection_name, owned_tokens_dictionary_key, _token_id_string) =
+            runtime::call_contract::<(String, Key, String)>(
+                nft_contract_hash,
+                ENTRY_POINT_MINT,
+                runtime_args! {
+                    ARG_TOKEN_OWNER => token_owner,
+                    ARG_TOKEN_META_DATA => token_metadata,
+                },
+            );
 
         runtime::put_key(&collection_name, owned_tokens_dictionary_key)
     } else {
@@ -68,9 +73,9 @@ pub extern "C" fn mint() {
             nft_contract_hash,
             ENTRY_POINT_MINT,
             runtime_args! {
-            ARG_TOKEN_OWNER => token_owner,
-            ARG_TOKEN_META_DATA => token_metadata,
-        },
+                ARG_TOKEN_OWNER => token_owner,
+                ARG_TOKEN_META_DATA => token_metadata,
+            },
         );
     }
 }
@@ -93,7 +98,7 @@ pub extern "C" fn transfer() {
             ARG_TOKEN_ID => token_id,
             ARG_SOURCE_KEY => from_token_owner,
             ARG_TARGET_KEY => target_token_owner
-        }
+        },
     );
 
     runtime::put_key(&collection_name, owned_tokens_dictionary_key)
@@ -113,10 +118,9 @@ pub extern "C" fn burn() {
         ENTRY_POINT_BURN,
         runtime_args! {
             ARG_TOKEN_ID => token_id
-        }
+        },
     )
 }
-
 
 #[no_mangle]
 pub extern "C" fn metadata() {
@@ -132,7 +136,7 @@ pub extern "C" fn metadata() {
         ENTRY_POINT_METADATA,
         runtime_args! {
             ARG_TOKEN_ID => token_id
-        }
+        },
     );
 
     runtime::put_key("metadata", storage::new_uref(metadata).into());
@@ -152,10 +156,9 @@ pub extern "C" fn register_contract() {
         ENTRY_POINT_REGISTER_OWNER,
         runtime_args! {
             ARG_TOKEN_OWNER => token_owner
-        }
+        },
     );
 }
-
 
 fn install_minting_contract() -> (ContractHash, ContractVersion) {
     let mint_entry_point = EntryPoint::new(
@@ -166,7 +169,7 @@ fn install_minting_contract() -> (ContractHash, ContractVersion) {
             Parameter::new(ARG_TOKEN_META_DATA, CLType::String),
         ],
         CLType::Unit,
-            EntryPointAccess::Public,
+        EntryPointAccess::Public,
         EntryPointType::Session,
     );
 
@@ -195,7 +198,7 @@ fn install_minting_contract() -> (ContractHash, ContractVersion) {
         vec![Parameter::new(ARG_TOKEN_ID, CLType::U64)],
         CLType::Unit,
         EntryPointAccess::Public,
-        EntryPointType::Contract
+        EntryPointType::Contract,
     );
 
     let mut entry_points = EntryPoints::new();
@@ -225,4 +228,3 @@ pub extern "C" fn call() {
     runtime::put_key(CONTRACT_NAME, contract_hash.into());
     runtime::put_key(CONTRACT_VERSION, storage::new_uref(contract_version).into());
 }
-


### PR DESCRIPTION
This PR intends to remove dependancy to casper-serde-json-wasm in benefit of serde-json-wasm (with casper-contract/std as std import).

https://github.com/casper-ecosystem/cep-78-enhanced-nft/issues/157