### PR TITLE
Owned_Tokens Dictionary Deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ All notable changes to this project will be documented in this file.  The format
 
     * To allow isolation of the additional costs, or tracking individual owners, the reverse lookup mode supports a register entrypoint which is used to register owners prior to minting or receiving a transferred token. In either `Assigned` or `Transferable` mode, this register entrypoint can be called by any party on behalf of another party.
 
+    * As a result of this change, the previously used `owned_tokens` dictionary is now deprecated. Moving forward, token ownership will be tracked using the `OwnerReverseLookupMode` modality and [CEP-78 Page System](./README.md#the-cep-78-page-system).
     
 ### Changed 
 


### PR DESCRIPTION
### What does this PR fix/introduce?
[Note owned_tokens Deprecation in CEP-78 #984](https://github.com/casper-network/docs/issues/984)

Closes #984

### Additional context
`owned_tokens` was deprecated along with the introduction of the Page system, but this wasn't noted in the v1.1 release notes. This PR rectifies that problem.

### Checklist
(Delete any that aren't relevant)

- [x] All external links have been verified with `yarn run check:externals`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casperlabs.io/workflow/contribute/).

### Reviewers
@darthsiroftardis 