### PR TITLE
omit dev dependencies when running audit

### DIFF
--- a/.github/workflows/ci-cep-78-client.yml
+++ b/.github/workflows/ci-cep-78-client.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Audits
         working-directory: ./client-js
-        run: npm audit
+        run: npm audit --omit=dev
 
       - name: Lints
         working-directory: ./client-js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "cep-78-enhanced-nft",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Same as in [`casper-js-sdk`](https://github.com/casper-ecosystem/casper-js-sdk/pull/322)