### PR TITLE
Fix wrong def of ARG_TRANSFER_FILTER_CONTRACT in init entry point

### DIFF
--- a/contract/src/main.rs
+++ b/contract/src/main.rs
@@ -1947,10 +1947,7 @@ fn generate_entry_points() -> EntryPoints {
             Parameter::new(ARG_METADATA_MUTABILITY, CLType::U8),
             Parameter::new(ARG_OWNER_LOOKUP_MODE, CLType::U8),
             Parameter::new(ARG_EVENTS_MODE, CLType::U8),
-            Parameter::new(
-                ARG_TRANSFER_FILTER_CONTRACT,
-                CLType::Option(Box::new(CLType::Key)),
-            ),
+            Parameter::new(ARG_TRANSFER_FILTER_CONTRACT, CLType::Key),
         ],
         CLType::Unit,
         EntryPointAccess::Public,

--- a/tests/src/utility/installer_request_builder.rs
+++ b/tests/src/utility/installer_request_builder.rs
@@ -326,7 +326,7 @@ impl InstallerRequestBuilder {
     }
 
     pub(crate) fn with_transfer_filter_contract(mut self, transfer_filter_contract: Key) -> Self {
-        self.transfer_filter_contract = CLValue::from_t(transfer_filter_contract).unwrap();
+        self.transfer_filter_contract = Some(CLValue::from_t(transfer_filter_contract).unwrap());
         self
     }
 
@@ -364,7 +364,9 @@ impl InstallerRequestBuilder {
             runtime_args.insert_cl_value(ARG_JSON_SCHEMA, self.json_schema);
         }
 
-        runtime_args.insert_cl_value(ARG_TRANSFER_FILTER_CONTRACT, transfer_filter_contract);
+        if let Some(transfer_filter_contract) = self.transfer_filter_contract {
+            runtime_args.insert_cl_value(ARG_TRANSFER_FILTER_CONTRACT, transfer_filter_contract);
+        }
         ExecuteRequestBuilder::standard(self.account_hash, &self.session_file, runtime_args).build()
     }
 }

--- a/tests/src/utility/installer_request_builder.rs
+++ b/tests/src/utility/installer_request_builder.rs
@@ -326,7 +326,7 @@ impl InstallerRequestBuilder {
     }
 
     pub(crate) fn with_transfer_filter_contract(mut self, transfer_filter_contract: Key) -> Self {
-        self.transfer_filter_contract = Some(CLValue::from_t(transfer_filter_contract).unwrap());
+        self.transfer_filter_contract = CLValue::from_t(transfer_filter_contract).unwrap();
         self
     }
 
@@ -364,9 +364,7 @@ impl InstallerRequestBuilder {
             runtime_args.insert_cl_value(ARG_JSON_SCHEMA, self.json_schema);
         }
 
-        if let Some(transfer_filter_contract) = self.transfer_filter_contract {
-            runtime_args.insert_cl_value(ARG_TRANSFER_FILTER_CONTRACT, transfer_filter_contract);
-        }
+        runtime_args.insert_cl_value(ARG_TRANSFER_FILTER_CONTRACT, transfer_filter_contract);
         ExecuteRequestBuilder::standard(self.account_hash, &self.session_file, runtime_args).build()
     }
 }


### PR DESCRIPTION
I believe the definition of ARG_TRANSFER_FILTER_CONTRACT for init entry point is not correct because it is supposed to be value/no value but not an option as this is a optional parameter in init() and it manages it as the option it self if no value. 