### PR TITLE
Wrong error on insertion of duplicated token identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,3 +296,4 @@ by using the provided `Makefile` and running the `make test` command.
 | 167  | InvalidOperatorBurnMode                     |
 | 168  | MissingOperatorBurnMode                     |
 | 169  | InvalidIdentifier                           |
+| 170  | DuplicateIdentifier                         |

--- a/contract/src/error.rs
+++ b/contract/src/error.rs
@@ -172,6 +172,7 @@ pub enum NFTCoreError {
     InvalidOperatorBurnMode = 167,
     MissingOperatorBurnMode = 168,
     InvalidIdentifier = 169,
+    DuplicateIdentifier = 170,
 }
 
 impl From<NFTCoreError> for ApiError {

--- a/contract/src/utils.rs
+++ b/contract/src/utils.rs
@@ -452,7 +452,7 @@ pub fn insert_hash_id_lookups(
     .unwrap_or_revert()
     .is_some()
     {
-        runtime::revert(NFTCoreError::InvalidNFTMetadataKind)
+        runtime::revert(NFTCoreError::DuplicateIdentifier)
     }
     if storage::dictionary_get::<String>(
         hash_by_index_uref,
@@ -461,7 +461,7 @@ pub fn insert_hash_id_lookups(
     .unwrap_or_revert()
     .is_some()
     {
-        runtime::revert(NFTCoreError::MissingNftKind)
+        runtime::revert(NFTCoreError::DuplicateIdentifier)
     }
     storage::dictionary_put(
         hash_by_index_uref,


### PR DESCRIPTION
When you try to insert the same token identifier, the error is not correct and misleading in `utils::insert_hash_id_lookups`

Adding two tests to check the new error.