### PR TITLE
Contract level messages wire-up

### DIFF
--- a/client/balance_of_session/Cargo.toml
+++ b/client/balance_of_session/Cargo.toml
@@ -4,8 +4,8 @@ version = "1.4.0"
 edition = "2018"
 
 [dependencies]
-casper-contract = "2.0.0"
-casper-types = "2.0.0"
+casper-contract = "*"
+casper-types = "*"
 
 [[bin]]
 name = "balance_of_call"
@@ -17,3 +17,7 @@ test = false
 [profile.release]
 codegen-units = 1
 lto = true
+
+[patch.crates-io]
+casper-types = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }
+casper-contract = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }

--- a/client/balance_of_session/src/main.rs
+++ b/client/balance_of_session/src/main.rs
@@ -8,7 +8,7 @@ extern crate alloc;
 use alloc::string::String;
 
 use casper_contract::contract_api::{runtime, storage};
-use casper_types::{runtime_args, ContractHash, Key, RuntimeArgs};
+use casper_types::{runtime_args, AddressableEntityHash, Key};
 
 const ENTRY_POINT_BALANCE_OF: &str = "balance_of";
 const ARG_NFT_CONTRACT_HASH: &str = "nft_contract_hash";
@@ -17,10 +17,10 @@ const ARG_KEY_NAME: &str = "key_name";
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let nft_contract_hash: ContractHash = runtime::get_named_arg::<Key>(ARG_NFT_CONTRACT_HASH)
-        .into_hash()
-        .map(ContractHash::new)
-        .unwrap();
+    let nft_contract_hash: AddressableEntityHash =
+        runtime::get_named_arg::<Key>(ARG_NFT_CONTRACT_HASH)
+            .into_entity_hash()
+            .unwrap();
     let key_name: String = runtime::get_named_arg(ARG_KEY_NAME);
     let token_owner: Key = runtime::get_named_arg(ARG_TOKEN_OWNER);
 

--- a/client/get_approved_session/Cargo.toml
+++ b/client/get_approved_session/Cargo.toml
@@ -4,8 +4,8 @@ version = "1.4.0"
 edition = "2018"
 
 [dependencies]
-casper-contract = "2.0.0"
-casper-types = "2.0.0"
+casper-contract = "*"
+casper-types = "*"
 
 [[bin]]
 name = "get_approved_call"
@@ -17,3 +17,7 @@ test = false
 [profile.release]
 codegen-units = 1
 lto = true
+
+[patch.crates-io]
+casper-types = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }
+casper-contract = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }

--- a/client/get_approved_session/src/main.rs
+++ b/client/get_approved_session/src/main.rs
@@ -8,7 +8,7 @@ extern crate alloc;
 use alloc::string::String;
 
 use casper_contract::contract_api::{runtime, storage};
-use casper_types::{runtime_args, ContractHash, Key, RuntimeArgs};
+use casper_types::{runtime_args, AddressableEntityHash, Key};
 
 const ENTRY_POINT_GET_APPROVED: &str = "get_approved";
 const ARG_NFT_CONTRACT_HASH: &str = "nft_contract_hash";
@@ -19,10 +19,10 @@ const ARG_IS_HASH_IDENTIFIER_MODE: &str = "is_hash_identifier_mode";
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let nft_contract_hash: ContractHash = runtime::get_named_arg::<Key>(ARG_NFT_CONTRACT_HASH)
-        .into_hash()
-        .map(ContractHash::new)
-        .unwrap();
+    let nft_contract_hash: AddressableEntityHash =
+        runtime::get_named_arg::<Key>(ARG_NFT_CONTRACT_HASH)
+            .into_entity_hash()
+            .unwrap();
     let key_name: String = runtime::get_named_arg(ARG_KEY_NAME);
 
     let maybe_approved_account = if runtime::get_named_arg::<bool>(ARG_IS_HASH_IDENTIFIER_MODE) {

--- a/client/is_approved_for_all_session/Cargo.toml
+++ b/client/is_approved_for_all_session/Cargo.toml
@@ -4,8 +4,8 @@ version = "1.4.0"
 edition = "2018"
 
 [dependencies]
-casper-contract = "2.0.0"
-casper-types = "2.0.0"
+casper-contract = "*"
+casper-types = "*"
 
 [[bin]]
 name = "is_approved_for_all_call"
@@ -17,3 +17,7 @@ test = false
 [profile.release]
 codegen-units = 1
 lto = true
+
+[patch.crates-io]
+casper-types = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }
+casper-contract = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }

--- a/client/is_approved_for_all_session/src/main.rs
+++ b/client/is_approved_for_all_session/src/main.rs
@@ -8,7 +8,7 @@ extern crate alloc;
 use alloc::string::String;
 
 use casper_contract::contract_api::{runtime, storage};
-use casper_types::{runtime_args, ContractHash, Key, RuntimeArgs};
+use casper_types::{runtime_args, AddressableEntityHash, Key};
 
 const ENTRY_POINT_IS_APPROVED_FOR_ALL: &str = "is_approved_for_all";
 const ARG_NFT_CONTRACT_HASH: &str = "nft_contract_hash";
@@ -18,10 +18,10 @@ const ARG_OPERATOR: &str = "operator";
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let nft_contract_hash: ContractHash = runtime::get_named_arg::<Key>(ARG_NFT_CONTRACT_HASH)
-        .into_hash()
-        .map(|hash| ContractHash::new(hash))
-        .unwrap();
+    let nft_contract_hash: AddressableEntityHash =
+        runtime::get_named_arg::<Key>(ARG_NFT_CONTRACT_HASH)
+            .into_entity_hash()
+            .unwrap();
 
     let key_name: String = runtime::get_named_arg(ARG_KEY_NAME);
     let owner = runtime::get_named_arg::<Key>(ARG_TOKEN_OWNER);

--- a/client/mint_session/Cargo.toml
+++ b/client/mint_session/Cargo.toml
@@ -4,8 +4,8 @@ version = "1.4.0"
 edition = "2018"
 
 [dependencies]
-casper-contract = "2.0.0"
-casper-types = "2.0.0"
+casper-contract = "*"
+casper-types = "*"
 
 [[bin]]
 name = "mint_call"
@@ -17,3 +17,7 @@ test = false
 [profile.release]
 codegen-units = 1
 lto = true
+
+[patch.crates-io]
+casper-types = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }
+casper-contract = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }

--- a/client/mint_session/src/main.rs
+++ b/client/mint_session/src/main.rs
@@ -9,7 +9,7 @@ extern crate alloc;
 use alloc::{format, string::String};
 
 use casper_contract::contract_api::runtime;
-use casper_types::{runtime_args, ContractHash, Key, RuntimeArgs, URef};
+use casper_types::{runtime_args, AddressableEntityHash, Key, URef};
 
 const ENTRY_POINT_MINT: &str = "mint";
 const ENTRY_POINT_REGISTER_OWNER: &str = "register_owner";
@@ -22,10 +22,10 @@ pub const PREFIX_CEP78: &str = "cep78";
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let nft_contract_hash: ContractHash = runtime::get_named_arg::<Key>(ARG_NFT_CONTRACT_HASH)
-        .into_hash()
-        .map(ContractHash::new)
-        .unwrap();
+    let nft_contract_hash: AddressableEntityHash =
+        runtime::get_named_arg::<Key>(ARG_NFT_CONTRACT_HASH)
+            .into_entity_hash()
+            .unwrap();
 
     let token_owner = runtime::get_named_arg::<Key>(ARG_TOKEN_OWNER);
     let token_metadata: String = runtime::get_named_arg(ARG_TOKEN_META_DATA);

--- a/client/owner_of_session/Cargo.toml
+++ b/client/owner_of_session/Cargo.toml
@@ -4,8 +4,8 @@ version = "1.4.0"
 edition = "2018"
 
 [dependencies]
-casper-contract = "2.0.0"
-casper-types = "2.0.0"
+casper-contract = "*"
+casper-types = "*"
 
 [[bin]]
 name = "owner_of_call"
@@ -17,3 +17,7 @@ test = false
 [profile.release]
 codegen-units = 1
 lto = true
+
+[patch.crates-io]
+casper-types = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }
+casper-contract = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }

--- a/client/owner_of_session/src/main.rs
+++ b/client/owner_of_session/src/main.rs
@@ -8,7 +8,7 @@ extern crate alloc;
 use alloc::string::String;
 
 use casper_contract::contract_api::{runtime, storage};
-use casper_types::{runtime_args, ContractHash, Key, RuntimeArgs};
+use casper_types::{runtime_args, AddressableEntityHash, Key};
 
 const ENTRY_POINT_OWNER_OF: &str = "owner_of";
 const ARG_NFT_CONTRACT_HASH: &str = "nft_contract_hash";
@@ -19,10 +19,10 @@ const ARG_IS_HASH_IDENTIFIER_MODE: &str = "is_hash_identifier_mode";
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let nft_contract_hash: ContractHash = runtime::get_named_arg::<Key>(ARG_NFT_CONTRACT_HASH)
-        .into_hash()
-        .map(ContractHash::new)
-        .unwrap();
+    let nft_contract_hash: AddressableEntityHash =
+        runtime::get_named_arg::<Key>(ARG_NFT_CONTRACT_HASH)
+            .into_entity_hash()
+            .unwrap();
     let key_name: String = runtime::get_named_arg(ARG_KEY_NAME);
 
     let owner = if runtime::get_named_arg(ARG_IS_HASH_IDENTIFIER_MODE) {

--- a/client/transfer_session/Cargo.toml
+++ b/client/transfer_session/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-casper-contract = "2.0.0"
-casper-types = "2.0.0"
+casper-contract = "*"
+casper-types = "*"
 
 [[bin]]
 name = "transfer_call"
@@ -19,3 +19,7 @@ test = false
 [profile.release]
 codegen-units = 1
 lto = true
+
+[patch.crates-io]
+casper-types = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }
+casper-contract = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }

--- a/client/transfer_session/src/main.rs
+++ b/client/transfer_session/src/main.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 use alloc::string::String;
 
 use casper_contract::contract_api::runtime;
-use casper_types::{runtime_args, ContractHash, Key, RuntimeArgs};
+use casper_types::{runtime_args, AddressableEntityHash, Key};
 
 const ENTRY_POINT_TRANSFER: &str = "transfer";
 
@@ -19,10 +19,10 @@ const ARG_SOURCE_KEY: &str = "source_key";
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let nft_contract_hash: ContractHash = runtime::get_named_arg::<Key>(ARG_NFT_CONTRACT_HASH)
-        .into_hash()
-        .map(ContractHash::new)
-        .unwrap();
+    let nft_contract_hash: AddressableEntityHash =
+        runtime::get_named_arg::<Key>(ARG_NFT_CONTRACT_HASH)
+            .into_entity_hash()
+            .unwrap();
 
     let source_key: Key = runtime::get_named_arg(ARG_SOURCE_KEY);
     let target_key: Key = runtime::get_named_arg(ARG_TARGET_KEY);

--- a/client/updated_receipts/Cargo.toml
+++ b/client/updated_receipts/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-casper-contract = "2.0.0"
-casper-types = "2.0.0"
+casper-contract = "*"
+casper-types = "*"
 
 [[bin]]
 name = "updated_receipts"
@@ -19,3 +19,7 @@ test = false
 [profile.release]
 codegen-units = 1
 lto = true
+
+[patch.crates-io]
+casper-types = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }
+casper-contract = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }

--- a/client/updated_receipts/src/main.rs
+++ b/client/updated_receipts/src/main.rs
@@ -9,17 +9,16 @@ extern crate alloc;
 use alloc::{string::String, vec::Vec};
 
 use casper_contract::{contract_api::runtime, unwrap_or_revert::UnwrapOrRevert};
-use casper_types::{self, runtime_args, ContractPackageHash, Key, RuntimeArgs};
+use casper_types::{self, runtime_args, Key, PackageHash};
 
 const ENTRY_POINT_UPDATE_RECEIPTS: &str = "updated_receipts";
 pub(crate) const ARG_NFT_CONTRACT_PACKAGE_HASH: &str = "nft_contract_package_hash";
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let nft_package_hash: ContractPackageHash =
+    let nft_package_hash: PackageHash =
         runtime::get_named_arg::<Key>(ARG_NFT_CONTRACT_PACKAGE_HASH)
-            .into_hash()
-            .map(ContractPackageHash::new)
+            .into_package_hash()
             .unwrap_or_revert();
 
     // This value represents a list of receipt names and addresses corresponding

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -4,15 +4,15 @@ version = "1.4.0"
 edition = "2018"
 
 [dependencies]
-casper-contract = { version = "2.0.0", default-features = false, features = [
+casper-contract = { version = "*", default-features = false, features = [
   "test-support",
 ], optional = true }
-casper-types = "2.0.0"
+casper-types = "*"
 serde = { version = "1.0.80", default-features = false }
 serde_json = { version = "1.0.59", default-features = false }
 serde-json-wasm = { version = "0.5.1", default-features = false }
 base16 = { version = "0.2.1", default-features = false }
-casper-event-standard = { version = "0.3.0", default-features = false }
+casper-event-standard = { version = "*", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 
 [[bin]]
@@ -29,3 +29,7 @@ lto = true
 [features]
 default = ["contract-support"]
 contract-support = ["dep:casper-contract"]
+
+[patch.crates-io]
+casper-types = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }
+casper-contract = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }

--- a/contract/src/events.rs
+++ b/contract/src/events.rs
@@ -4,3 +4,5 @@ pub mod events_ces;
 // as a library and a binary.
 #[cfg(feature = "contract-support")]
 pub mod events_cep47;
+
+pub mod native;

--- a/contract/src/events/native.rs
+++ b/contract/src/events/native.rs
@@ -1,0 +1,55 @@
+use core::convert::TryFrom;
+
+use crate::modalities::TokenIdentifier;
+use casper_types::{contract_messages::MessagePayload, Key};
+use serde::Serialize;
+pub const EVENTS_TOPIC: &str = "events";
+
+#[derive(Serialize)]
+pub enum CEP78Message {
+    Mint {
+        recipient: Key,
+        token_id: TokenIdentifier,
+    },
+    Burn {
+        owner: Key,
+        token_id: TokenIdentifier,
+        burner: Key,
+    },
+    ApprovalGranted {
+        owner: Key,
+        spender: Key,
+        token_id: TokenIdentifier,
+    },
+    ApprovalRevoked {
+        owner: Key,
+        token_id: TokenIdentifier,
+    },
+    ApprovalForAll {
+        owner: Key,
+        operator: Key,
+    },
+    RevokedForAll {
+        owner: Key,
+        operator: Key,
+    },
+    Transfer {
+        sender: Key,
+        recipient: Key,
+        token_id: TokenIdentifier,
+    },
+    MetadataUpdate {
+        token_id: TokenIdentifier,
+    },
+    VariablesSet,
+    Migrate,
+}
+
+impl TryFrom<CEP78Message> for MessagePayload {
+    type Error = serde_json::Error;
+
+    fn try_from(value: CEP78Message) -> Result<Self, Self::Error> {
+        let json_value = serde_json::to_string(&value)?;
+        Ok(json_value.into())
+    }
+}

--- a/contract/src/modalities.rs
+++ b/contract/src/modalities.rs
@@ -5,6 +5,8 @@ use alloc::{
     vec::Vec,
 };
 
+use serde::Serialize;
+
 use casper_types::{
     bytesrepr::{self, FromBytes, ToBytes, U64_SERIALIZED_LENGTH, U8_SERIALIZED_LENGTH},
     CLType, CLTyped,
@@ -268,7 +270,7 @@ impl TryFrom<u8> for MetadataMutability {
     }
 }
 
-#[derive(PartialEq, Eq, Clone)]
+#[derive(PartialEq, Eq, Clone, Serialize)]
 pub enum TokenIdentifier {
     Index(u64),
     Hash(String),
@@ -429,6 +431,7 @@ pub enum EventsMode {
     NoEvents = 0,
     CEP47 = 1,
     CES = 2,
+    Native = 3,
 }
 
 impl TryFrom<u8> for EventsMode {
@@ -439,6 +442,7 @@ impl TryFrom<u8> for EventsMode {
             0 => Ok(EventsMode::NoEvents),
             1 => Ok(EventsMode::CEP47),
             2 => Ok(EventsMode::CES),
+            3 => Ok(EventsMode::Native),
             _ => Err(NFTCoreError::InvalidEventsMode),
         }
     }

--- a/test-contracts/mangle_named_keys/Cargo.toml
+++ b/test-contracts/mangle_named_keys/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-casper-contract = "2.0.0"
-casper-types = "2.0.0"
+casper-contract = "*"
+casper-types = "*"
 
 [[bin]]
 name = "mangle_named_keys"
@@ -19,3 +19,7 @@ test = false
 [profile.release]
 codegen-units = 1
 lto = true
+
+[patch.crates-io]
+casper-types = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }
+casper-contract = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }

--- a/test-contracts/minting_contract/Cargo.toml
+++ b/test-contracts/minting_contract/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-casper-contract = "2.0.0"
-casper-types = "2.0.0"
+casper-contract = "*"
+casper-types = "*"
 
 [[bin]]
 name = "minting_contract"
@@ -19,3 +19,7 @@ test = false
 [profile.release]
 codegen-units = 1
 lto = true
+
+[patch.crates-io]
+casper-types = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }
+casper-contract = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }

--- a/test-contracts/minting_contract/src/main.rs
+++ b/test-contracts/minting_contract/src/main.rs
@@ -15,8 +15,8 @@ use casper_contract::{
     unwrap_or_revert::UnwrapOrRevert,
 };
 use casper_types::{
-    contracts::NamedKeys, runtime_args, CLType, ContractHash, ContractPackageHash, ContractVersion,
-    EntryPoint, EntryPointAccess, EntryPointType, EntryPoints, Key, Parameter, RuntimeArgs, URef,
+    addressable_entity::NamedKeys, runtime_args, AddressableEntityHash, CLType, EntityVersion,
+    EntryPoint, EntryPointAccess, EntryPointType, EntryPoints, Key, PackageHash, Parameter, URef,
 };
 
 const CONTRACT_NAME: &str = "minting_contract_hash";
@@ -44,10 +44,10 @@ const ARG_REVERSE_LOOKUP: &str = "reverse_lookup";
 
 #[no_mangle]
 pub extern "C" fn mint() {
-    let nft_contract_hash: ContractHash = runtime::get_named_arg::<Key>(ARG_NFT_CONTRACT_HASH)
-        .into_hash()
-        .map(ContractHash::new)
-        .unwrap();
+    let nft_contract_hash: AddressableEntityHash =
+        runtime::get_named_arg::<Key>(ARG_NFT_CONTRACT_HASH)
+            .into_entity_hash()
+            .unwrap();
 
     let token_owner = runtime::get_named_arg::<Key>(ARG_TOKEN_OWNER);
     let token_metadata: String = runtime::get_named_arg(ARG_TOKEN_META_DATA);
@@ -87,10 +87,10 @@ pub extern "C" fn mint() {
 
 #[no_mangle]
 pub extern "C" fn approve() {
-    let nft_contract_hash: ContractHash = runtime::get_named_arg::<Key>(ARG_NFT_CONTRACT_HASH)
-        .into_hash()
-        .map(ContractHash::new)
-        .unwrap();
+    let nft_contract_hash: AddressableEntityHash =
+        runtime::get_named_arg::<Key>(ARG_NFT_CONTRACT_HASH)
+            .into_entity_hash()
+            .unwrap();
 
     let token_id = runtime::get_named_arg::<u64>(ARG_TOKEN_ID);
     let spender_key = runtime::get_named_arg::<Key>(ARG_SPENDER);
@@ -107,10 +107,10 @@ pub extern "C" fn approve() {
 
 #[no_mangle]
 pub extern "C" fn revoke() {
-    let nft_contract_hash: ContractHash = runtime::get_named_arg::<Key>(ARG_NFT_CONTRACT_HASH)
-        .into_hash()
-        .map(ContractHash::new)
-        .unwrap();
+    let nft_contract_hash: AddressableEntityHash =
+        runtime::get_named_arg::<Key>(ARG_NFT_CONTRACT_HASH)
+            .into_entity_hash()
+            .unwrap();
 
     let token_id = runtime::get_named_arg::<u64>(ARG_TOKEN_ID);
 
@@ -125,10 +125,10 @@ pub extern "C" fn revoke() {
 
 #[no_mangle]
 pub extern "C" fn transfer() {
-    let nft_contract_hash: ContractHash = runtime::get_named_arg::<Key>(ARG_NFT_CONTRACT_HASH)
-        .into_hash()
-        .map(ContractHash::new)
-        .unwrap();
+    let nft_contract_hash: AddressableEntityHash =
+        runtime::get_named_arg::<Key>(ARG_NFT_CONTRACT_HASH)
+            .into_entity_hash()
+            .unwrap();
 
     let token_id = runtime::get_named_arg::<u64>(ARG_TOKEN_ID);
     let from_token_owner = runtime::get_named_arg::<Key>(ARG_SOURCE_KEY);
@@ -149,10 +149,10 @@ pub extern "C" fn transfer() {
 
 #[no_mangle]
 pub extern "C" fn burn() {
-    let nft_contract_hash: ContractHash = runtime::get_named_arg::<Key>(ARG_NFT_CONTRACT_HASH)
-        .into_hash()
-        .map(ContractHash::new)
-        .unwrap();
+    let nft_contract_hash: AddressableEntityHash =
+        runtime::get_named_arg::<Key>(ARG_NFT_CONTRACT_HASH)
+            .into_entity_hash()
+            .unwrap();
 
     let token_id = runtime::get_named_arg::<u64>(ARG_TOKEN_ID);
 
@@ -167,10 +167,10 @@ pub extern "C" fn burn() {
 
 #[no_mangle]
 pub extern "C" fn metadata() {
-    let nft_contract_hash: ContractHash = runtime::get_named_arg::<Key>(ARG_NFT_CONTRACT_HASH)
-        .into_hash()
-        .map(ContractHash::new)
-        .unwrap();
+    let nft_contract_hash: AddressableEntityHash =
+        runtime::get_named_arg::<Key>(ARG_NFT_CONTRACT_HASH)
+            .into_entity_hash()
+            .unwrap();
 
     let token_id = runtime::get_named_arg::<u64>(ARG_TOKEN_ID);
 
@@ -187,10 +187,10 @@ pub extern "C" fn metadata() {
 
 #[no_mangle]
 pub extern "C" fn register_contract() {
-    let nft_contract_hash: ContractHash = runtime::get_named_arg::<Key>(ARG_NFT_CONTRACT_HASH)
-        .into_hash()
-        .map(ContractHash::new)
-        .unwrap();
+    let nft_contract_hash: AddressableEntityHash =
+        runtime::get_named_arg::<Key>(ARG_NFT_CONTRACT_HASH)
+            .into_entity_hash()
+            .unwrap();
 
     let token_owner = runtime::get_named_arg::<Key>(ARG_TOKEN_OWNER);
 
@@ -203,7 +203,7 @@ pub extern "C" fn register_contract() {
     );
 }
 
-fn install_minting_contract() -> (ContractHash, ContractVersion) {
+fn install_minting_contract() -> (AddressableEntityHash, EntityVersion) {
     let entry_points = get_entry_points();
     let named_keys = named_keys();
     storage::new_contract(
@@ -214,13 +214,11 @@ fn install_minting_contract() -> (ContractHash, ContractVersion) {
     )
 }
 
-fn upgrade_minting_contract(name: &str) -> (ContractHash, ContractVersion) {
-    let contract_package_hash: ContractPackageHash = ContractPackageHash::new(
-        runtime::get_key(name)
-            .unwrap_or_revert()
-            .into_hash()
-            .unwrap_or_revert(),
-    );
+fn upgrade_minting_contract(name: &str) -> (AddressableEntityHash, EntityVersion) {
+    let contract_package_hash: PackageHash = runtime::get_key(name)
+        .unwrap_or_revert()
+        .into_package_hash()
+        .unwrap_or_revert();
     let named_keys = named_keys();
     let entry_points = get_entry_points();
     storage::add_contract_version(contract_package_hash, entry_points, named_keys)
@@ -242,7 +240,7 @@ fn get_entry_points() -> EntryPoints {
         ],
         CLType::Unit,
         EntryPointAccess::Public,
-        EntryPointType::Session,
+        EntryPointType::AddressableEntity,
     );
 
     let approve_entry_point = EntryPoint::new(
@@ -250,7 +248,7 @@ fn get_entry_points() -> EntryPoints {
         vec![Parameter::new(ARG_SPENDER, CLType::Key)],
         CLType::Unit,
         EntryPointAccess::Public,
-        EntryPointType::Contract,
+        EntryPointType::AddressableEntity,
     );
 
     let revoke_entry_point = EntryPoint::new(
@@ -258,7 +256,7 @@ fn get_entry_points() -> EntryPoints {
         vec![],
         CLType::Unit,
         EntryPointAccess::Public,
-        EntryPointType::Contract,
+        EntryPointType::AddressableEntity,
     );
 
     let transfer_entry_point = EntryPoint::new(
@@ -270,7 +268,7 @@ fn get_entry_points() -> EntryPoints {
         ],
         CLType::Unit,
         EntryPointAccess::Public,
-        EntryPointType::Contract,
+        EntryPointType::AddressableEntity,
     );
 
     let burn_entry_point = EntryPoint::new(
@@ -278,7 +276,7 @@ fn get_entry_points() -> EntryPoints {
         vec![Parameter::new(ARG_TOKEN_ID, CLType::U64)],
         CLType::Unit,
         EntryPointAccess::Public,
-        EntryPointType::Contract,
+        EntryPointType::AddressableEntity,
     );
 
     let metadata_entry_point = EntryPoint::new(
@@ -286,7 +284,7 @@ fn get_entry_points() -> EntryPoints {
         vec![Parameter::new(ARG_TOKEN_ID, CLType::U64)],
         CLType::Unit,
         EntryPointAccess::Public,
-        EntryPointType::Contract,
+        EntryPointType::AddressableEntity,
     );
     let mut entry_points = EntryPoints::new();
     entry_points.add_entry_point(mint_entry_point);
@@ -307,6 +305,6 @@ pub extern "C" fn call() {
         install_minting_contract()
     };
 
-    runtime::put_key(CONTRACT_NAME, contract_hash.into());
+    runtime::put_key(CONTRACT_NAME, Key::contract_entity_key(contract_hash));
     runtime::put_key(CONTRACT_VERSION, storage::new_uref(contract_version).into());
 }

--- a/test-contracts/transfer_filter_contract/Cargo.toml
+++ b/test-contracts/transfer_filter_contract/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-casper-contract = "2.0.0"
-casper-types = "2.0.0"
+casper-contract = "*"
+casper-types = "*"
 
 [[bin]]
 name = "transfer_filter_contract"
@@ -19,3 +19,7 @@ test = false
 [profile.release]
 codegen-units = 1
 lto = true
+
+[patch.crates-io]
+casper-types = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }
+casper-contract = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }

--- a/test-contracts/transfer_filter_contract/src/main.rs
+++ b/test-contracts/transfer_filter_contract/src/main.rs
@@ -13,8 +13,8 @@ use casper_contract::contract_api::{
     storage,
 };
 use casper_types::{
-    contracts::NamedKeys, CLType, CLValue, ContractHash, ContractVersion, EntryPoint,
-    EntryPointAccess, EntryPointType, EntryPoints, Key, Parameter,
+    addressable_entity::NamedKeys, AddressableEntityHash, CLType, CLValue, EntityVersion,
+    EntryPoint, EntryPointAccess, EntryPointType, EntryPoints, Key, Parameter,
 };
 
 const CONTRACT_NAME: &str = "transfer_filter_contract_hash";
@@ -23,7 +23,7 @@ const HASH_KEY_NAME: &str = "transfer_filter_contract_package_hash";
 const ACCESS_KEY_NAME: &str = "transfer_filter_contract_access_uref";
 const ARG_FILTER_CONTRACT_RETURN_VALUE: &str = "return_value";
 
-fn install_filter_contract() -> (ContractHash, ContractVersion) {
+fn install_filter_contract() -> (AddressableEntityHash, EntityVersion) {
     let can_transfer_entry_point = EntryPoint::new(
         "can_transfer",
         vec![
@@ -32,7 +32,7 @@ fn install_filter_contract() -> (ContractHash, ContractVersion) {
         ],
         CLType::U8,
         EntryPointAccess::Public,
-        EntryPointType::Contract,
+        EntryPointType::AddressableEntity,
     );
 
     let set_return_value = EntryPoint::new(
@@ -40,7 +40,7 @@ fn install_filter_contract() -> (ContractHash, ContractVersion) {
         vec![Parameter::new(ARG_FILTER_CONTRACT_RETURN_VALUE, CLType::U8)],
         CLType::Unit,
         EntryPointAccess::Public,
-        EntryPointType::Contract,
+        EntryPointType::AddressableEntity,
     );
 
     let mut entry_points = EntryPoints::new();
@@ -90,6 +90,6 @@ pub extern "C" fn can_transfer() {
 pub extern "C" fn call() {
     let (contract_hash, contract_version) = install_filter_contract();
 
-    runtime::put_key(CONTRACT_NAME, contract_hash.into());
+    runtime::put_key(CONTRACT_NAME, Key::contract_entity_key(contract_hash));
     runtime::put_key(CONTRACT_VERSION, storage::new_uref(contract_version).into());
 }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -3,12 +3,10 @@ name = "tests"
 version = "1.4.0"
 edition = "2018"
 [dependencies]
-casper-engine-test-support = { version = "4.0.0", default-features = false, features = [
-  "test-support",
-] }
+casper-engine-test-support = { version = "*", default-features = false }
 contract = { path = "../contract", default-features = false }
-casper-execution-engine = { version = "4.0.0", default-features = false }
-casper-types = "2.0.0"
+casper-execution-engine = { version = "*", default-features = false }
+casper-types = "*"
 serde = { version = "1.0.80", default-features = false }
 serde_json = { version = "1.0.59", default-features = false }
 once_cell = "1"
@@ -16,4 +14,10 @@ blake2 = { version = "0.9.0", default-features = false }
 base16 = { version = "0.2.1", default-features = false }
 rand = "0.8.5"
 sha256 = "1.0.3"
-casper-event-standard = { version = "0.3.0", default-features = false }
+casper-event-standard = { version = "*", default-features = false }
+casper-storage = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }
+
+[patch.crates-io]
+casper-types = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }
+casper-engine-test-support = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }
+casper-execution-engine = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }

--- a/tests/src/acl.rs
+++ b/tests/src/acl.rs
@@ -16,10 +16,10 @@ use crate::utility::{
     },
 };
 use casper_engine_test_support::{
-    ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
+    ExecuteRequestBuilder, LmdbWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
     PRODUCTION_RUN_GENESIS_REQUEST,
 };
-use casper_types::{runtime_args, ContractHash, Key, RuntimeArgs};
+use casper_types::{runtime_args, AddressableEntityHash, Key};
 use contract::{
     constants::{
         ACL_WHITELIST, ARG_ACL_WHITELIST, ARG_COLLECTION_NAME, ARG_CONTRACT_WHITELIST,
@@ -33,7 +33,7 @@ use contract::{
 
 #[test]
 fn should_install_with_acl_whitelist() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -52,7 +52,7 @@ fn should_install_with_acl_whitelist() {
 
     let minting_contract_hash = get_minting_contract_hash(&builder);
 
-    let contract_whitelist = vec![Key::from(minting_contract_hash)];
+    let contract_whitelist = vec![Key::contract_entity_key(minting_contract_hash)];
 
     let install_request = InstallerRequestBuilder::new(*DEFAULT_ACCOUNT_ADDR, NFT_CONTRACT_WASM)
         .with_total_token_supply(100u64)
@@ -66,7 +66,7 @@ fn should_install_with_acl_whitelist() {
 
     builder.exec(install_request).expect_success().commit();
 
-    let nft_contract_key: Key = get_nft_contract_hash(&builder).into();
+    let nft_contract_key: Key = Key::contract_entity_key(get_nft_contract_hash(&builder));
 
     let is_whitelisted_contract = support::get_dictionary_value_from_key::<bool>(
         &builder,
@@ -80,7 +80,7 @@ fn should_install_with_acl_whitelist() {
 
 #[test]
 fn should_install_with_deprecated_contract_whitelist() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -113,7 +113,7 @@ fn should_install_with_deprecated_contract_whitelist() {
 
     builder.exec(install_request).expect_success().commit();
 
-    let nft_contract_key: Key = get_nft_contract_hash(&builder).into();
+    let nft_contract_key: Key = Key::contract_entity_key(get_nft_contract_hash(&builder));
 
     let is_whitelisted_contract = support::get_dictionary_value_from_key::<bool>(
         &builder,
@@ -127,12 +127,12 @@ fn should_install_with_deprecated_contract_whitelist() {
 
 #[test]
 fn should_not_install_with_minting_mode_not_acl_if_acl_whitelist_provided() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
 
-    let contract_whitelist = vec![ContractHash::default()];
+    let contract_whitelist = vec![AddressableEntityHash::default()];
 
     let install_request = InstallerRequestBuilder::new(*DEFAULT_ACCOUNT_ADDR, NFT_CONTRACT_WASM)
         .with_total_token_supply(100u64)
@@ -157,7 +157,7 @@ fn should_not_install_with_minting_mode_not_acl_if_acl_whitelist_provided() {
 fn should_disallow_installation_of_contract_with_empty_locked_whitelist_in_public_mode_with_holder_mode(
     nft_holder_mode: NFTHolderMode,
 ) {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -187,7 +187,7 @@ fn should_allow_installation_of_contract_with_empty_locked_whitelist_in_public_m
 
 #[test]
 fn should_disallow_installation_with_contract_holder_mode_and_installer_mode() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -218,7 +218,7 @@ fn should_disallow_installation_with_contract_holder_mode_and_installer_mode() {
 
 #[test]
 fn should_allow_whitelisted_account_to_mint() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -239,7 +239,7 @@ fn should_allow_whitelisted_account_to_mint() {
     builder.exec(install_request).expect_success().commit();
 
     let nft_contract_hash = get_nft_contract_hash(&builder);
-    let nft_contract_key: Key = nft_contract_hash.into();
+    let nft_contract_key: Key = Key::contract_entity_key(nft_contract_hash);
 
     let is_whitelisted_account = get_dictionary_value_from_key::<bool>(
         &builder,
@@ -283,7 +283,7 @@ fn should_allow_whitelisted_account_to_mint() {
 
 #[test]
 fn should_disallow_unlisted_account_from_minting() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -303,7 +303,7 @@ fn should_disallow_unlisted_account_from_minting() {
     builder.exec(install_request).expect_success().commit();
 
     let nft_contract_hash = get_nft_contract_hash(&builder);
-    let nft_contract_key: Key = nft_contract_hash.into();
+    let nft_contract_key: Key = Key::contract_entity_key(nft_contract_hash);
 
     let is_whitelisted_account = get_dictionary_value_from_key::<bool>(
         &builder,
@@ -343,7 +343,7 @@ fn should_disallow_unlisted_account_from_minting() {
 
 #[test]
 fn should_allow_whitelisted_contract_to_mint() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -362,7 +362,7 @@ fn should_allow_whitelisted_contract_to_mint() {
 
     let minting_contract_hash = get_minting_contract_hash(&builder);
 
-    let contract_whitelist = vec![Key::from(minting_contract_hash)];
+    let contract_whitelist = vec![Key::contract_entity_key(minting_contract_hash)];
 
     let install_request = InstallerRequestBuilder::new(*DEFAULT_ACCOUNT_ADDR, NFT_CONTRACT_WASM)
         .with_total_token_supply(100u64)
@@ -376,7 +376,7 @@ fn should_allow_whitelisted_contract_to_mint() {
 
     builder.exec(install_request).expect_success().commit();
 
-    let nft_contract_key: Key = get_nft_contract_hash(&builder).into();
+    let nft_contract_key: Key = Key::contract_entity_key(get_nft_contract_hash(&builder));
 
     let is_whitelisted_contract = get_dictionary_value_from_key::<bool>(
         &builder,
@@ -389,7 +389,7 @@ fn should_allow_whitelisted_contract_to_mint() {
 
     let mint_runtime_args = runtime_args! {
         ARG_NFT_CONTRACT_HASH => nft_contract_key,
-        ARG_TOKEN_OWNER => Key::from(minting_contract_hash),
+        ARG_TOKEN_OWNER => Key::contract_entity_key(minting_contract_hash),
         ARG_TOKEN_META_DATA => TEST_PRETTY_721_META_DATA.to_string(),
         ARG_REVERSE_LOOKUP => false
     };
@@ -416,14 +416,14 @@ fn should_allow_whitelisted_contract_to_mint() {
         &token_id.to_string(),
     );
 
-    let minting_contract_key: Key = minting_contract_hash.into();
+    let minting_contract_key: Key = Key::contract_entity_key(minting_contract_hash);
 
     assert_eq!(actual_token_owner, minting_contract_key)
 }
 
 #[test]
 fn should_disallow_unlisted_contract_from_minting() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -459,11 +459,11 @@ fn should_disallow_unlisted_contract_from_minting() {
 
     builder.exec(install_request).expect_success().commit();
 
-    let nft_contract_key: Key = get_nft_contract_hash(&builder).into();
+    let nft_contract_key: Key = Key::contract_entity_key(get_nft_contract_hash(&builder));
 
     let mint_runtime_args = runtime_args! {
         ARG_NFT_CONTRACT_HASH => nft_contract_key,
-        ARG_TOKEN_OWNER => Key::from(minting_contract_hash),
+        ARG_TOKEN_OWNER => Key::contract_entity_key(minting_contract_hash),
         ARG_TOKEN_META_DATA => TEST_PRETTY_721_META_DATA.to_string(),
         ARG_REVERSE_LOOKUP => false
     };
@@ -488,7 +488,7 @@ fn should_disallow_unlisted_contract_from_minting() {
 
 #[test]
 fn should_allow_mixed_account_contract_to_mint() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -507,7 +507,10 @@ fn should_allow_mixed_account_contract_to_mint() {
 
     let minting_contract_hash = get_minting_contract_hash(&builder);
     let account_user_1 = support::create_funded_dummy_account(&mut builder, Some(ACCOUNT_USER_1));
-    let mixed_whitelist = vec![Key::from(minting_contract_hash), Key::from(account_user_1)];
+    let mixed_whitelist = vec![
+        Key::contract_entity_key(minting_contract_hash),
+        Key::from(account_user_1),
+    ];
 
     let install_request = InstallerRequestBuilder::new(*DEFAULT_ACCOUNT_ADDR, NFT_CONTRACT_WASM)
         .with_total_token_supply(100u64)
@@ -522,7 +525,7 @@ fn should_allow_mixed_account_contract_to_mint() {
     builder.exec(install_request).expect_success().commit();
 
     let nft_contract_hash = get_nft_contract_hash(&builder);
-    let nft_contract_key: Key = get_nft_contract_hash(&builder).into();
+    let nft_contract_key: Key = Key::contract_entity_key(get_nft_contract_hash(&builder));
 
     // Contract
     let is_whitelisted_contract = get_dictionary_value_from_key::<bool>(
@@ -536,7 +539,7 @@ fn should_allow_mixed_account_contract_to_mint() {
 
     let mint_runtime_args = runtime_args! {
         ARG_NFT_CONTRACT_HASH => nft_contract_key,
-        ARG_TOKEN_OWNER => Key::from(minting_contract_hash),
+        ARG_TOKEN_OWNER => Key::contract_entity_key(minting_contract_hash),
         ARG_TOKEN_META_DATA => TEST_PRETTY_721_META_DATA.to_string(),
         ARG_REVERSE_LOOKUP => false
     };
@@ -563,7 +566,7 @@ fn should_allow_mixed_account_contract_to_mint() {
         &token_id.to_string(),
     );
 
-    let minting_contract_key: Key = minting_contract_hash.into();
+    let minting_contract_key: Key = Key::contract_entity_key(minting_contract_hash);
 
     assert_eq!(actual_token_owner, minting_contract_key);
 
@@ -610,7 +613,7 @@ fn should_allow_mixed_account_contract_to_mint() {
 
 #[test]
 fn should_disallow_unlisted_contract_from_minting_with_mixed_account_contract() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -630,7 +633,7 @@ fn should_disallow_unlisted_contract_from_minting_with_mixed_account_contract() 
     let minting_contract_hash = get_minting_contract_hash(&builder);
     let account_user_1 = support::create_funded_dummy_account(&mut builder, Some(ACCOUNT_USER_1));
     let mixed_whitelist = vec![
-        Key::from(ContractHash::from([1u8; 32])),
+        Key::contract_entity_key(AddressableEntityHash::from([1u8; 32])),
         Key::from(account_user_1),
     ];
 
@@ -646,11 +649,11 @@ fn should_disallow_unlisted_contract_from_minting_with_mixed_account_contract() 
 
     builder.exec(install_request).expect_success().commit();
 
-    let nft_contract_key: Key = get_nft_contract_hash(&builder).into();
+    let nft_contract_key: Key = Key::contract_entity_key(get_nft_contract_hash(&builder));
 
     let mint_runtime_args = runtime_args! {
         ARG_NFT_CONTRACT_HASH => nft_contract_key,
-        ARG_TOKEN_OWNER => Key::from(minting_contract_hash),
+        ARG_TOKEN_OWNER => Key::contract_entity_key(minting_contract_hash),
         ARG_TOKEN_META_DATA => TEST_PRETTY_721_META_DATA.to_string(),
         ARG_REVERSE_LOOKUP => false
     };
@@ -675,7 +678,7 @@ fn should_disallow_unlisted_contract_from_minting_with_mixed_account_contract() 
 
 #[test]
 fn should_disallow_unlisted_account_from_minting_with_mixed_account_contract() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -694,7 +697,7 @@ fn should_disallow_unlisted_account_from_minting_with_mixed_account_contract() {
 
     let minting_contract_hash = get_minting_contract_hash(&builder);
     let mixed_whitelist = vec![
-        Key::from(minting_contract_hash),
+        Key::contract_entity_key(minting_contract_hash),
         Key::from(*DEFAULT_ACCOUNT_ADDR),
     ];
 
@@ -711,7 +714,7 @@ fn should_disallow_unlisted_account_from_minting_with_mixed_account_contract() {
     builder.exec(install_request).expect_success().commit();
 
     let nft_contract_hash = get_nft_contract_hash(&builder);
-    let nft_contract_key: Key = nft_contract_hash.into();
+    let nft_contract_key: Key = Key::contract_entity_key(nft_contract_hash);
 
     let is_whitelisted_account = get_dictionary_value_from_key::<bool>(
         &builder,
@@ -751,7 +754,7 @@ fn should_disallow_unlisted_account_from_minting_with_mixed_account_contract() {
 
 #[test]
 fn should_disallow_listed_account_from_minting_with_nftholder_contract() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -770,7 +773,7 @@ fn should_disallow_listed_account_from_minting_with_nftholder_contract() {
 
     let minting_contract_hash = get_minting_contract_hash(&builder);
     let mixed_whitelist = vec![
-        Key::from(minting_contract_hash),
+        Key::contract_entity_key(minting_contract_hash),
         Key::from(*DEFAULT_ACCOUNT_ADDR),
     ];
 
@@ -787,7 +790,7 @@ fn should_disallow_listed_account_from_minting_with_nftholder_contract() {
     builder.exec(install_request).expect_success().commit();
 
     let nft_contract_hash = get_nft_contract_hash(&builder);
-    let nft_contract_key: Key = nft_contract_hash.into();
+    let nft_contract_key: Key = Key::contract_entity_key(nft_contract_hash);
 
     let is_whitelisted_account = get_dictionary_value_from_key::<bool>(
         &builder,
@@ -823,7 +826,7 @@ fn should_disallow_listed_account_from_minting_with_nftholder_contract() {
 
 #[test]
 fn should_disallow_contract_from_whitelisted_package_to_mint_without_acl_package_mode() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -857,7 +860,7 @@ fn should_disallow_contract_from_whitelisted_package_to_mint_without_acl_package
 
     builder.exec(install_request).expect_success().commit();
 
-    let nft_contract_key: Key = get_nft_contract_hash(&builder).into();
+    let nft_contract_key: Key = Key::contract_entity_key(get_nft_contract_hash(&builder));
 
     let is_whitelisted_contract_package = get_dictionary_value_from_key::<bool>(
         &builder,
@@ -873,7 +876,7 @@ fn should_disallow_contract_from_whitelisted_package_to_mint_without_acl_package
 
     let mint_runtime_args = runtime_args! {
         ARG_NFT_CONTRACT_HASH => nft_contract_key,
-        ARG_TOKEN_OWNER => Key::from(minting_contract_hash),
+        ARG_TOKEN_OWNER => Key::contract_entity_key(minting_contract_hash),
         ARG_TOKEN_META_DATA => TEST_PRETTY_721_META_DATA.to_string(),
         ARG_REVERSE_LOOKUP => false
     };
@@ -898,7 +901,7 @@ fn should_disallow_contract_from_whitelisted_package_to_mint_without_acl_package
 
 #[test]
 fn should_allow_contract_from_whitelisted_package_to_mint_with_acl_package_mode() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -934,7 +937,7 @@ fn should_allow_contract_from_whitelisted_package_to_mint_with_acl_package_mode(
 
     builder.exec(install_request).expect_success().commit();
 
-    let nft_contract_key: Key = get_nft_contract_hash(&builder).into();
+    let nft_contract_key: Key = Key::contract_entity_key(get_nft_contract_hash(&builder));
 
     let is_whitelisted_contract_package = get_dictionary_value_from_key::<bool>(
         &builder,
@@ -950,7 +953,7 @@ fn should_allow_contract_from_whitelisted_package_to_mint_with_acl_package_mode(
 
     let mint_runtime_args = runtime_args! {
         ARG_NFT_CONTRACT_HASH => nft_contract_key,
-        ARG_TOKEN_OWNER => Key::from(minting_contract_hash),
+        ARG_TOKEN_OWNER => Key::contract_entity_key(minting_contract_hash),
         ARG_TOKEN_META_DATA => TEST_PRETTY_721_META_DATA.to_string(),
         ARG_REVERSE_LOOKUP => false
     };
@@ -977,7 +980,7 @@ fn should_allow_contract_from_whitelisted_package_to_mint_with_acl_package_mode(
         &token_id.to_string(),
     );
 
-    let minting_contract_key: Key = minting_contract_hash.into();
+    let minting_contract_key: Key = Key::contract_entity_key(minting_contract_hash);
 
     assert_eq!(actual_token_owner, minting_contract_key)
 }
@@ -985,7 +988,7 @@ fn should_allow_contract_from_whitelisted_package_to_mint_with_acl_package_mode(
 #[test]
 fn should_allow_contract_from_whitelisted_package_to_mint_with_acl_package_mode_after_contract_upgrade(
 ) {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -1021,7 +1024,7 @@ fn should_allow_contract_from_whitelisted_package_to_mint_with_acl_package_mode_
 
     builder.exec(install_request).expect_success().commit();
 
-    let nft_contract_key: Key = get_nft_contract_hash(&builder).into();
+    let nft_contract_key: Key = Key::contract_entity_key(get_nft_contract_hash(&builder));
 
     let is_whitelisted_contract_package = get_dictionary_value_from_key::<bool>(
         &builder,
@@ -1065,7 +1068,7 @@ fn should_allow_contract_from_whitelisted_package_to_mint_with_acl_package_mode_
 
     let mint_runtime_args = runtime_args! {
         ARG_NFT_CONTRACT_HASH => nft_contract_key,
-        ARG_TOKEN_OWNER => Key::from(minting_contract_hash),
+        ARG_TOKEN_OWNER => Key::contract_entity_key(minting_contract_hash),
         ARG_TOKEN_META_DATA => TEST_PRETTY_721_META_DATA.to_string(),
         ARG_REVERSE_LOOKUP => false
     };
@@ -1092,7 +1095,7 @@ fn should_allow_contract_from_whitelisted_package_to_mint_with_acl_package_mode_
         &token_id.to_string(),
     );
 
-    let minting_contract_key: Key = minting_upgraded_contract_hash.into();
+    let minting_contract_key: Key = Key::contract_entity_key(minting_upgraded_contract_hash);
 
     assert_eq!(actual_token_owner, minting_contract_key)
 }
@@ -1101,7 +1104,7 @@ fn should_allow_contract_from_whitelisted_package_to_mint_with_acl_package_mode_
 
 #[test]
 fn should_be_able_to_update_whitelist_for_minting_with_deprecated_arg_contract_whitelist() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -1135,12 +1138,12 @@ fn should_be_able_to_update_whitelist_for_minting_with_deprecated_arg_contract_w
     builder.exec(install_request).expect_success().commit();
 
     let nft_contract_hash = get_nft_contract_hash(&builder);
-    let nft_contract_key: Key = nft_contract_hash.into();
+    let nft_contract_key: Key = Key::contract_entity_key(nft_contract_hash);
 
     let seed_uref = *builder
         .query(None, nft_contract_key, &[])
         .expect("must have nft contract")
-        .as_contract()
+        .as_addressable_entity()
         .expect("must convert contract")
         .named_keys()
         .get(ACL_WHITELIST)
@@ -1220,7 +1223,7 @@ fn should_be_able_to_update_whitelist_for_minting_with_deprecated_arg_contract_w
 
 #[test]
 fn should_be_able_to_update_whitelist_for_minting() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -1254,12 +1257,12 @@ fn should_be_able_to_update_whitelist_for_minting() {
     builder.exec(install_request).expect_success().commit();
 
     let nft_contract_hash = get_nft_contract_hash(&builder);
-    let nft_contract_key: Key = nft_contract_hash.into();
+    let nft_contract_key: Key = Key::contract_entity_key(nft_contract_hash);
 
     let seed_uref = *builder
         .query(None, nft_contract_key, &[])
         .expect("must have nft contract")
-        .as_contract()
+        .as_addressable_entity()
         .expect("must convert contract")
         .named_keys()
         .get(ACL_WHITELIST)
@@ -1304,7 +1307,7 @@ fn should_be_able_to_update_whitelist_for_minting() {
         nft_contract_hash,
         ENTRY_POINT_SET_VARIABLES,
         runtime_args! {
-            ARG_ACL_WHITELIST => vec![Key::from(minting_contract_hash)]
+            ARG_ACL_WHITELIST => vec![Key::contract_entity_key(minting_contract_hash)]
         },
     )
     .build();
@@ -1339,9 +1342,10 @@ fn should_be_able_to_update_whitelist_for_minting() {
 
 // Upgrade
 
+#[ignore = "old wasms use `casper_add_contract_version` which was replaced with `casper_add_package_version`"]
 #[test]
 fn should_upgrade_from_named_keys_to_dict_and_acl_minting_mode() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -1377,7 +1381,7 @@ fn should_upgrade_from_named_keys_to_dict_and_acl_minting_mode() {
     builder.exec(install_request).expect_success().commit();
 
     let nft_contract_hash_1_0_0 = support::get_nft_contract_hash_1_0_0(&builder);
-    let nft_contract_key_1_0_0: Key = nft_contract_hash_1_0_0.into();
+    let nft_contract_key_1_0_0: Key = Key::contract_entity_key(nft_contract_hash_1_0_0);
 
     let minting_mode = support::query_stored_value::<u8>(
         &builder,
@@ -1404,7 +1408,7 @@ fn should_upgrade_from_named_keys_to_dict_and_acl_minting_mode() {
 
     builder.exec(upgrade_request).expect_success().commit();
 
-    let nft_contract_key: Key = support::get_nft_contract_hash(&builder).into();
+    let nft_contract_key: Key = Key::contract_entity_key(support::get_nft_contract_hash(&builder));
 
     let is_updated_acl_whitelist = get_dictionary_value_from_key::<bool>(
         &builder,

--- a/tests/src/costs.rs
+++ b/tests/src/costs.rs
@@ -1,8 +1,8 @@
 use casper_engine_test_support::{
-    ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
+    ExecuteRequestBuilder, LmdbWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
     PRODUCTION_RUN_GENESIS_REQUEST,
 };
-use casper_types::{account::AccountHash, runtime_args, Key, RuntimeArgs};
+use casper_types::{account::AccountHash, runtime_args, Key};
 use contract::constants::{
     ARG_COLLECTION_NAME, ARG_SOURCE_KEY, ARG_TARGET_KEY, ARG_TOKEN_ID, ARG_TOKEN_META_DATA,
     ARG_TOKEN_OWNER, ENTRY_POINT_REGISTER_OWNER,
@@ -22,7 +22,7 @@ use crate::utility::{
 
 #[test]
 fn mint_cost_should_remain_stable() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -38,7 +38,7 @@ fn mint_cost_should_remain_stable() {
 
     builder.exec(install_request).expect_success().commit();
 
-    let nft_contract_key: Key = support::get_nft_contract_hash(&builder).into();
+    let nft_contract_key: Key = Key::contract_entity_key(support::get_nft_contract_hash(&builder));
 
     let first_mint_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -94,7 +94,7 @@ fn mint_cost_should_remain_stable() {
 
 #[test]
 fn transfer_costs_should_remain_stable() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -111,7 +111,7 @@ fn transfer_costs_should_remain_stable() {
     builder.exec(install_request).expect_success().commit();
 
     let nft_contract_hash = support::get_nft_contract_hash(&builder);
-    let nft_contract_key: Key = nft_contract_hash.into();
+    let nft_contract_key: Key = Key::contract_entity_key(nft_contract_hash);
 
     for _ in 0..3 {
         let mint_request = ExecuteRequestBuilder::standard(
@@ -206,7 +206,7 @@ fn transfer_costs_should_remain_stable() {
 }
 
 fn should_cost_less_when_installing_without_reverse_lookup(reporting: OwnerReverseLookupMode) {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -225,7 +225,8 @@ fn should_cost_less_when_installing_without_reverse_lookup(reporting: OwnerRever
 
     let reverse_lookup_gas_cost = builder.last_exec_gas_cost();
 
-    let reverse_lookup_hash: Key = support::get_nft_contract_hash(&builder).into();
+    let reverse_lookup_hash: Key =
+        Key::contract_entity_key(support::get_nft_contract_hash(&builder));
 
     let page_dictionary_lookup = builder.query(None, reverse_lookup_hash, &["page_0".to_string()]);
 
@@ -245,7 +246,7 @@ fn should_cost_less_when_installing_without_reverse_lookup(reporting: OwnerRever
 
     let no_lookup_gas_cost = builder.last_exec_gas_cost();
 
-    let no_lookup_hash: Key = support::get_nft_contract_hash(&builder).into();
+    let no_lookup_hash: Key = Key::contract_entity_key(support::get_nft_contract_hash(&builder));
 
     let page_dictionary_lookup = builder.query(None, no_lookup_hash, &["page_0".to_string()]);
 

--- a/tests/src/events.rs
+++ b/tests/src/events.rs
@@ -1,11 +1,11 @@
 use std::collections::BTreeMap;
 
 use casper_engine_test_support::{
-    ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
+    ExecuteRequestBuilder, LmdbWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
     PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_event_standard::EVENTS_DICT;
-use casper_types::{account::AccountHash, runtime_args, Key, RuntimeArgs};
+use casper_types::{account::AccountHash, runtime_args, Key};
 
 use contract::{
     constants::{
@@ -44,7 +44,7 @@ use crate::utility::{
 // cep47 event style
 #[test]
 fn should_record_cep47_dictionary_style_mint_event() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -60,7 +60,7 @@ fn should_record_cep47_dictionary_style_mint_event() {
         .expect_success()
         .commit();
 
-    let nft_contract_key: Key = get_nft_contract_hash(&builder).into();
+    let nft_contract_key: Key = Key::contract_entity_key(get_nft_contract_hash(&builder));
 
     let mint_session_call = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -109,7 +109,7 @@ fn should_record_cep47_dictionary_style_mint_event() {
 
 #[test]
 fn should_record_cep47_dictionary_style_transfer_token_event_in_hash_identifier_mode() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -125,7 +125,7 @@ fn should_record_cep47_dictionary_style_transfer_token_event_in_hash_identifier_
     builder.exec(install_request).expect_success().commit();
 
     let nft_contract_hash = get_nft_contract_hash(&builder);
-    let nft_contract_key: Key = nft_contract_hash.into();
+    let nft_contract_key: Key = Key::contract_entity_key(nft_contract_hash);
 
     let mint_session_call = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -216,7 +216,7 @@ fn should_record_cep47_dictionary_style_metadata_update_event_for_nft721_using_t
     let nft_metadata_kind = NFTMetadataKind::NFT721;
     let identifier_mode = NFTIdentifierMode::Ordinal;
 
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -236,7 +236,7 @@ fn should_record_cep47_dictionary_style_metadata_update_event_for_nft721_using_t
 
     builder.exec(install_request).expect_success().commit();
 
-    let nft_contract_key: Key = get_nft_contract_hash(&builder).into();
+    let nft_contract_key: Key = Key::contract_entity_key(get_nft_contract_hash(&builder));
 
     let custom_metadata = serde_json::to_string_pretty(&*TEST_CUSTOM_METADATA)
         .expect("must convert to json metadata");
@@ -371,7 +371,7 @@ fn should_record_cep47_dictionary_style_metadata_update_event_for_nft721_using_t
 #[test]
 fn should_cep47_dictionary_style_burn_event() {
     let token_id = 0u64;
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -389,7 +389,7 @@ fn should_cep47_dictionary_style_burn_event() {
         .expect_success()
         .commit();
 
-    let nft_contract_key: Key = get_nft_contract_hash(&builder).into();
+    let nft_contract_key: Key = Key::contract_entity_key(get_nft_contract_hash(&builder));
 
     let mint_session_call = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -493,7 +493,7 @@ fn should_cep47_dictionary_style_burn_event() {
 
 #[test]
 fn should_cep47_dictionary_style_approve_event_in_hash_identifier_mode() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -509,7 +509,7 @@ fn should_cep47_dictionary_style_approve_event_in_hash_identifier_mode() {
     builder.exec(install_request).expect_success().commit();
 
     let nft_contract_hash = get_nft_contract_hash(&builder);
-    let nft_contract_key: Key = nft_contract_hash.into();
+    let nft_contract_key: Key = Key::contract_entity_key(nft_contract_hash);
 
     let mint_session_call = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -592,7 +592,7 @@ fn should_cep47_dictionary_style_approve_event_in_hash_identifier_mode() {
 
 #[test]
 fn should_cep47_dictionary_style_approvall_for_all_event() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -609,7 +609,7 @@ fn should_cep47_dictionary_style_approvall_for_all_event() {
         .commit();
 
     let nft_contract_hash = get_nft_contract_hash(&builder);
-    let nft_contract_key: Key = nft_contract_hash.into();
+    let nft_contract_key: Key = Key::contract_entity_key(nft_contract_hash);
 
     let mint_session_call = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -694,7 +694,7 @@ fn should_cep47_dictionary_style_approvall_for_all_event() {
 
 #[test]
 fn should_cep47_dictionary_style_revoked_for_all_event() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -711,7 +711,7 @@ fn should_cep47_dictionary_style_revoked_for_all_event() {
         .commit();
 
     let nft_contract_hash = get_nft_contract_hash(&builder);
-    let nft_contract_key: Key = nft_contract_hash.into();
+    let nft_contract_key: Key = Key::contract_entity_key(nft_contract_hash);
 
     let mint_session_call = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -810,11 +810,12 @@ fn should_cep47_dictionary_style_revoked_for_all_event() {
     assert_eq!(event, expected_event);
 }
 
+#[ignore = "old wasms use `casper_add_contract_version` which was replaced with `casper_add_package_version`"]
 #[test]
 fn should_record_migration_event_in_cep47() {
     const OWNED_TOKENS: &str = "owned_tokens";
 
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -831,7 +832,7 @@ fn should_record_migration_event_in_cep47() {
     builder.exec(install_request).expect_success().commit();
 
     let nft_contract_hash_1_0_0 = support::get_nft_contract_hash_1_0_0(&builder);
-    let nft_contract_key_1_0_0: Key = nft_contract_hash_1_0_0.into();
+    let nft_contract_key_1_0_0: Key = Key::contract_entity_key(nft_contract_hash_1_0_0);
 
     let number_of_tokens_pre_migration = 3usize;
 
@@ -862,7 +863,7 @@ fn should_record_migration_event_in_cep47() {
     let maybe_access_named_key = builder
         .query(None, Key::Account(*DEFAULT_ACCOUNT_ADDR), &[])
         .unwrap()
-        .as_account()
+        .as_addressable_entity()
         .unwrap()
         .named_keys()
         .get(ACCESS_KEY_NAME_1_0_0)
@@ -886,7 +887,7 @@ fn should_record_migration_event_in_cep47() {
 
     builder.exec(upgrade_request).expect_success().commit();
 
-    let nft_contract_key: Key = support::get_nft_contract_hash(&builder).into();
+    let nft_contract_key: Key = Key::contract_entity_key(support::get_nft_contract_hash(&builder));
 
     let latest_cep47_event_id =
         get_dictionary_value_from_key::<u64>(&builder, &nft_contract_key, EVENTS, "len") - 1u64;
@@ -917,7 +918,7 @@ fn should_record_migration_event_in_cep47() {
 
 #[test]
 fn should_not_have_events_dicts_in_no_events_mode() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -939,7 +940,7 @@ fn should_not_have_events_dicts_in_no_events_mode() {
 
     // Check dict from EventsMode::CEP47
     let contract = builder
-        .get_contract(contract_hash)
+        .get_addressable_entity(contract_hash)
         .expect("should have contract");
     let named_keys = contract.named_keys();
     let events = named_keys.get(EVENTS);
@@ -953,7 +954,7 @@ fn should_not_have_events_dicts_in_no_events_mode() {
 #[test]
 #[should_panic]
 fn should_not_record_events_in_no_events_mode() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -972,7 +973,7 @@ fn should_not_record_events_in_no_events_mode() {
         .commit();
 
     let contract_hash = get_nft_contract_hash(&builder);
-    let nft_contract_key: Key = contract_hash.into();
+    let nft_contract_key: Key = Key::contract_entity_key(contract_hash);
 
     let mint_session_call = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,

--- a/tests/src/set_variables.rs
+++ b/tests/src/set_variables.rs
@@ -1,8 +1,8 @@
 use casper_engine_test_support::{
-    ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
+    ExecuteRequestBuilder, LmdbWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
     PRODUCTION_RUN_GENESIS_REQUEST,
 };
-use casper_types::{runtime_args, ContractHash, Key, RuntimeArgs};
+use casper_types::{runtime_args, Key};
 use contract::{
     constants::{
         ACL_PACKAGE_MODE, ALLOW_MINTING, ARG_ACL_PACKAGE_MODE, ARG_ALLOW_MINTING,
@@ -23,7 +23,7 @@ use crate::utility::{
 
 #[test]
 fn only_installer_should_be_able_to_toggle_allow_minting() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -42,7 +42,7 @@ fn only_installer_should_be_able_to_toggle_allow_minting() {
     builder.exec(install_request).expect_success().commit();
 
     let nft_contract_hash = get_nft_contract_hash(&builder);
-    let nft_contract_key: Key = nft_contract_hash.into();
+    let nft_contract_key: Key = Key::contract_entity_key(nft_contract_hash);
 
     // Account other than installer account should not be able to change allow_minting
     // Red test
@@ -101,7 +101,7 @@ fn only_installer_should_be_able_to_toggle_allow_minting() {
 
 #[test]
 fn installer_should_be_able_to_toggle_acl_package_mode() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -115,15 +115,14 @@ fn installer_should_be_able_to_toggle_acl_package_mode() {
 
     builder.exec(install_request).expect_success().commit();
 
-    let account = builder.get_expected_account(*DEFAULT_ACCOUNT_ADDR);
+    let account = builder.get_expected_addressable_entity_by_account_hash(*DEFAULT_ACCOUNT_ADDR);
     let nft_contract_key: Key = *account
         .named_keys()
         .get(CONTRACT_NAME)
         .expect("must have key in named keys");
 
-    let nft_contract_hash = Key::into_hash(nft_contract_key)
-        .map(ContractHash::new)
-        .expect("failed to find nft contract");
+    let nft_contract_hash =
+        Key::into_entity_hash(nft_contract_key).expect("failed to find nft contract");
 
     let is_acl_packge_mode: bool = support::query_stored_value(
         &builder,
@@ -163,7 +162,7 @@ fn installer_should_be_able_to_toggle_acl_package_mode() {
 
 #[test]
 fn installer_should_be_able_to_toggle_package_operator_mode() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -177,15 +176,14 @@ fn installer_should_be_able_to_toggle_package_operator_mode() {
 
     builder.exec(install_request).expect_success().commit();
 
-    let account = builder.get_expected_account(*DEFAULT_ACCOUNT_ADDR);
+    let account = builder.get_expected_addressable_entity_by_account_hash(*DEFAULT_ACCOUNT_ADDR);
     let nft_contract_key: Key = *account
         .named_keys()
         .get(CONTRACT_NAME)
         .expect("must have key in named keys");
 
-    let nft_contract_hash = Key::into_hash(nft_contract_key)
-        .map(ContractHash::new)
-        .expect("failed to find nft contract");
+    let nft_contract_hash =
+        Key::into_entity_hash(nft_contract_key).expect("failed to find nft contract");
 
     let is_package_operator_mode: bool = support::query_stored_value(
         &builder,
@@ -225,7 +223,7 @@ fn installer_should_be_able_to_toggle_package_operator_mode() {
 
 #[test]
 fn installer_should_be_able_to_toggle_operator_burn_mode() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -239,15 +237,14 @@ fn installer_should_be_able_to_toggle_operator_burn_mode() {
 
     builder.exec(install_request).expect_success().commit();
 
-    let account = builder.get_expected_account(*DEFAULT_ACCOUNT_ADDR);
+    let account = builder.get_expected_addressable_entity_by_account_hash(*DEFAULT_ACCOUNT_ADDR);
     let nft_contract_key: Key = *account
         .named_keys()
         .get(CONTRACT_NAME)
         .expect("must have key in named keys");
 
-    let nft_contract_hash = Key::into_hash(nft_contract_key)
-        .map(ContractHash::new)
-        .expect("failed to find nft contract");
+    let nft_contract_hash =
+        Key::into_entity_hash(nft_contract_key).expect("failed to find nft contract");
 
     let is_package_operator_mode: bool = support::query_stored_value(
         &builder,

--- a/tests/src/upgrade.rs
+++ b/tests/src/upgrade.rs
@@ -1,9 +1,9 @@
 use casper_engine_test_support::{
-    ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
+    ExecuteRequestBuilder, LmdbWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
     PRODUCTION_RUN_GENESIS_REQUEST,
 };
 
-use casper_types::{account::AccountHash, runtime_args, CLValue, ContractHash, Key, RuntimeArgs};
+use casper_types::{account::AccountHash, runtime_args, CLValue, Key};
 use contract::{
     constants::{
         ACCESS_KEY_NAME_1_0_0, ACL_PACKAGE_MODE, ARG_ACCESS_KEY_NAME_1_0_0, ARG_ACL_PACKAGE_MODE,
@@ -37,9 +37,10 @@ const OWNED_TOKENS: &str = "owned_tokens";
 const MANGLED_ACCESS_KEY_NAME: &str = "mangled_access_key";
 const MANGLED_HASH_KEY_NAME: &str = "mangled_hash_key";
 
+#[ignore = "old wasms use `casper_add_contract_version` which was replaced with `casper_add_package_version`"]
 #[test]
 fn should_safely_upgrade_in_ordinal_identifier_mode() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -56,7 +57,7 @@ fn should_safely_upgrade_in_ordinal_identifier_mode() {
     builder.exec(install_request).expect_success().commit();
 
     let nft_contract_hash_1_0_0 = support::get_nft_contract_hash_1_0_0(&builder);
-    let nft_contract_key_1_0_0: Key = nft_contract_hash_1_0_0.into();
+    let nft_contract_key_1_0_0: Key = Key::contract_entity_key(nft_contract_hash_1_0_0);
 
     let number_of_tokens_pre_migration = 3usize;
 
@@ -86,7 +87,7 @@ fn should_safely_upgrade_in_ordinal_identifier_mode() {
     let maybe_access_named_key = builder
         .query(None, Key::Account(*DEFAULT_ACCOUNT_ADDR), &[])
         .unwrap()
-        .as_account()
+        .as_addressable_entity()
         .unwrap()
         .named_keys()
         .get(ACCESS_KEY_NAME_1_0_0)
@@ -110,7 +111,7 @@ fn should_safely_upgrade_in_ordinal_identifier_mode() {
 
     builder.exec(upgrade_request).expect_success().commit();
 
-    let nft_contract_key: Key = support::get_nft_contract_hash(&builder).into();
+    let nft_contract_key: Key = Key::contract_entity_key(support::get_nft_contract_hash(&builder));
 
     let actual_page_record_width = builder
         .query(None, nft_contract_key, &[PAGE_LIMIT.to_string()])
@@ -160,9 +161,10 @@ fn should_safely_upgrade_in_ordinal_identifier_mode() {
     builder.exec(mint_request).expect_success().commit();
 }
 
+#[ignore = "old wasms use `casper_add_contract_version` which was replaced with `casper_add_package_version`"]
 #[test]
 fn should_safely_upgrade_in_hash_identifier_mode() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -180,7 +182,7 @@ fn should_safely_upgrade_in_hash_identifier_mode() {
     builder.exec(install_request).expect_success().commit();
 
     let nft_contract_hash_1_0_0 = support::get_nft_contract_hash_1_0_0(&builder);
-    let nft_contract_key_1_0_0: Key = nft_contract_hash_1_0_0.into();
+    let nft_contract_key_1_0_0: Key = Key::contract_entity_key(nft_contract_hash_1_0_0);
 
     let mut expected_metadata: Vec<String> = vec![];
 
@@ -226,7 +228,7 @@ fn should_safely_upgrade_in_hash_identifier_mode() {
     let maybe_access_named_key = builder
         .query(None, Key::Account(*DEFAULT_ACCOUNT_ADDR), &[])
         .unwrap()
-        .as_account()
+        .as_addressable_entity()
         .unwrap()
         .named_keys()
         .get(ACCESS_KEY_NAME_1_0_0)
@@ -249,7 +251,7 @@ fn should_safely_upgrade_in_hash_identifier_mode() {
     builder.exec(upgrade_request).expect_success().commit();
 
     let nft_contract_hash = support::get_nft_contract_hash(&builder);
-    let nft_contract_key: Key = nft_contract_hash.into();
+    let nft_contract_key: Key = Key::contract_entity_key(nft_contract_hash);
 
     let number_of_tokens_at_upgrade = support::get_stored_value_from_global_state::<u64>(
         &builder,
@@ -352,9 +354,10 @@ fn should_safely_upgrade_in_hash_identifier_mode() {
     assert!(actual_page[2])
 }
 
+#[ignore = "old wasms use `casper_add_contract_version` which was replaced with `casper_add_package_version`"]
 #[test]
 fn should_update_receipts_post_upgrade_paged() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -371,7 +374,7 @@ fn should_update_receipts_post_upgrade_paged() {
     builder.exec(install_request).expect_success().commit();
 
     let nft_contract_hash_1_0_0 = support::get_nft_contract_hash_1_0_0(&builder);
-    let nft_contract_key_1_0_0: Key = nft_contract_hash_1_0_0.into();
+    let nft_contract_key_1_0_0: Key = Key::contract_entity_key(nft_contract_hash_1_0_0);
 
     let number_of_tokens_pre_migration = 20usize;
 
@@ -417,7 +420,7 @@ fn should_update_receipts_post_upgrade_paged() {
 
     builder.exec(migrate_request).expect_success().commit();
 
-    let nft_contract_key: Key = support::get_nft_contract_hash(&builder).into();
+    let nft_contract_key: Key = Key::contract_entity_key(support::get_nft_contract_hash(&builder));
 
     let nft_receipt: String = support::get_stored_value_from_global_state(
         &builder,
@@ -429,7 +432,7 @@ fn should_update_receipts_post_upgrade_paged() {
     let default_account = builder
         .query(None, Key::Account(*DEFAULT_ACCOUNT_ADDR), &[])
         .unwrap()
-        .as_account()
+        .as_addressable_entity()
         .unwrap()
         .clone();
 
@@ -447,9 +450,10 @@ fn should_update_receipts_post_upgrade_paged() {
     }
 }
 
+#[ignore = "old wasms use `casper_add_contract_version` which was replaced with `casper_add_package_version`"]
 #[test]
 fn should_not_be_able_to_reinvoke_migrate_entrypoint() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -515,9 +519,10 @@ fn should_not_be_able_to_reinvoke_migrate_entrypoint() {
     support::assert_expected_error(error, 126u16, "must have previously migrated error");
 }
 
+#[ignore = "old wasms use `casper_add_contract_version` which was replaced with `casper_add_package_version`"]
 #[test]
 fn should_not_migrate_contracts_with_zero_token_issuance() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -550,9 +555,10 @@ fn should_not_migrate_contracts_with_zero_token_issuance() {
     support::assert_expected_error(error, 122u16, "cannot upgrade when issuance is 0");
 }
 
+#[ignore = "old wasms use `casper_add_contract_version` which was replaced with `casper_add_package_version`"]
 #[test]
 fn should_upgrade_with_custom_named_keys() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -569,7 +575,7 @@ fn should_upgrade_with_custom_named_keys() {
     builder.exec(install_request).expect_success().commit();
 
     let nft_contract_hash_1_0_0 = support::get_nft_contract_hash_1_0_0(&builder);
-    let nft_contract_key_1_0_0: Key = nft_contract_hash_1_0_0.into();
+    let nft_contract_key_1_0_0: Key = Key::contract_entity_key(nft_contract_hash_1_0_0);
 
     let number_of_tokens_pre_migration = 3usize;
 
@@ -600,7 +606,7 @@ fn should_upgrade_with_custom_named_keys() {
     let maybe_access_named_key = builder
         .query(None, Key::Account(*DEFAULT_ACCOUNT_ADDR), &[])
         .unwrap()
-        .as_account()
+        .as_addressable_entity()
         .unwrap()
         .named_keys()
         .get(ACCESS_KEY_NAME_1_0_0)
@@ -658,9 +664,10 @@ fn should_upgrade_with_custom_named_keys() {
         .commit();
 }
 
+#[ignore = "old wasms use `casper_add_contract_version` which was replaced with `casper_add_package_version`"]
 #[test]
 fn should_not_upgrade_with_larger_total_token_supply() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -705,7 +712,7 @@ fn should_safely_upgrade_from_old_version_to_new_version_with_reporting_mode(
     reporting_mode: OwnerReverseLookupMode,
     expected_total_token_supply_post_upgrade: u64,
 ) {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -724,8 +731,8 @@ fn should_safely_upgrade_from_old_version_to_new_version_with_reporting_mode(
 
     builder.exec(install_request).expect_success().commit();
 
-    let nft_contract_hash: ContractHash = support::get_nft_contract_hash(&builder);
-    let nft_contract_key: Key = nft_contract_hash.into();
+    let nft_contract_hash = support::get_nft_contract_hash(&builder);
+    let nft_contract_key: Key = Key::contract_entity_key(nft_contract_hash);
 
     let number_of_tokens_pre_migration = 3usize;
 
@@ -772,7 +779,7 @@ fn should_safely_upgrade_from_old_version_to_new_version_with_reporting_mode(
 
     builder.exec(upgrade_request).expect_success().commit();
 
-    let nft_contract_key: Key = support::get_nft_contract_hash(&builder).into();
+    let nft_contract_key: Key = Key::contract_entity_key(support::get_nft_contract_hash(&builder));
 
     let number_of_tokens_at_upgrade = support::get_stored_value_from_global_state::<u64>(
         &builder,
@@ -799,7 +806,7 @@ fn should_safely_upgrade_from_old_version_to_new_version_with_reporting_mode(
     let seed_uref = *builder
         .query(None, nft_contract_key, &[])
         .expect("must have nft contract")
-        .as_contract()
+        .as_addressable_entity()
         .expect("must convert contract")
         .named_keys()
         .get(casper_event_standard::EVENTS_DICT)
@@ -812,9 +819,10 @@ fn should_safely_upgrade_from_old_version_to_new_version_with_reporting_mode(
         .expect_err("should not have dictionary value for a third migration event");
 }
 
+#[ignore = "old wasms use `casper_add_contract_version` which was replaced with `casper_add_package_version`"]
 #[test]
 fn should_safely_upgrade_with_acl_package_mode() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -831,15 +839,15 @@ fn should_safely_upgrade_with_acl_package_mode() {
     builder.exec(install_request).expect_success().commit();
 
     let nft_contract_hash_1_0_0 = support::get_nft_contract_hash_1_0_0(&builder);
-    let nft_contract_key_1_0_0: Key = nft_contract_hash_1_0_0.into();
+    let nft_contract_key_1_0_0: Key = Key::contract_entity_key(nft_contract_hash_1_0_0);
 
     let is_acl_packge_mode = builder
         .query(None, nft_contract_key_1_0_0, &[])
         .expect("must have nft contract")
-        .as_contract()
+        .as_addressable_entity()
         .expect("must convert contract")
         .named_keys()
-        .contains_key(ACL_PACKAGE_MODE);
+        .contains(ACL_PACKAGE_MODE);
 
     assert!(!is_acl_packge_mode);
 
@@ -859,7 +867,7 @@ fn should_safely_upgrade_with_acl_package_mode() {
     builder.exec(upgrade_request).expect_success().commit();
 
     let nft_contract_hash = support::get_nft_contract_hash(&builder);
-    let nft_contract_key: Key = nft_contract_hash.into();
+    let nft_contract_key: Key = Key::contract_entity_key(nft_contract_hash);
 
     let is_acl_packge_mode: bool = support::query_stored_value(
         &builder,
@@ -875,9 +883,10 @@ fn should_safely_upgrade_with_acl_package_mode() {
     assert_eq!(actual_event, expected_event, "Expected Migration event.");
 }
 
+#[ignore = "old wasms use `casper_add_contract_version` which was replaced with `casper_add_package_version`"]
 #[test]
 fn should_safely_upgrade_with_package_operator_mode() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -894,15 +903,15 @@ fn should_safely_upgrade_with_package_operator_mode() {
     builder.exec(install_request).expect_success().commit();
 
     let nft_contract_hash_1_0_0 = support::get_nft_contract_hash_1_0_0(&builder);
-    let nft_contract_key_1_0_0: Key = nft_contract_hash_1_0_0.into();
+    let nft_contract_key_1_0_0: Key = Key::contract_entity_key(nft_contract_hash_1_0_0);
 
     let is_package_operator_mode = builder
         .query(None, nft_contract_key_1_0_0, &[])
         .expect("must have nft contract")
-        .as_contract()
+        .as_addressable_entity()
         .expect("must convert contract")
         .named_keys()
-        .contains_key(PACKAGE_OPERATOR_MODE);
+        .contains(PACKAGE_OPERATOR_MODE);
 
     assert!(!is_package_operator_mode);
 
@@ -922,7 +931,7 @@ fn should_safely_upgrade_with_package_operator_mode() {
     builder.exec(upgrade_request).expect_success().commit();
 
     let nft_contract_hash = support::get_nft_contract_hash(&builder);
-    let nft_contract_key: Key = nft_contract_hash.into();
+    let nft_contract_key: Key = Key::contract_entity_key(nft_contract_hash);
 
     let is_package_operator_mode: bool = support::query_stored_value(
         &builder,
@@ -938,9 +947,10 @@ fn should_safely_upgrade_with_package_operator_mode() {
     assert_eq!(actual_event, expected_event, "Expected Migration event.");
 }
 
+#[ignore = "old wasms use `casper_add_contract_version` which was replaced with `casper_add_package_version`"]
 #[test]
 fn should_safely_upgrade_with_operator_burn_mode() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -957,15 +967,15 @@ fn should_safely_upgrade_with_operator_burn_mode() {
     builder.exec(install_request).expect_success().commit();
 
     let nft_contract_hash_1_0_0 = support::get_nft_contract_hash_1_0_0(&builder);
-    let nft_contract_key_1_0_0: Key = nft_contract_hash_1_0_0.into();
+    let nft_contract_key_1_0_0: Key = Key::contract_entity_key(nft_contract_hash_1_0_0);
 
     let is_operator_burn_mode = builder
         .query(None, nft_contract_key_1_0_0, &[])
         .expect("must have nft contract")
-        .as_contract()
+        .as_addressable_entity()
         .expect("must convert contract")
         .named_keys()
-        .contains_key(OPERATOR_BURN_MODE);
+        .contains(OPERATOR_BURN_MODE);
 
     assert!(!is_operator_burn_mode);
 
@@ -985,7 +995,7 @@ fn should_safely_upgrade_with_operator_burn_mode() {
     builder.exec(upgrade_request).expect_success().commit();
 
     let nft_contract_hash = support::get_nft_contract_hash(&builder);
-    let nft_contract_key: Key = nft_contract_hash.into();
+    let nft_contract_key: Key = Key::contract_entity_key(nft_contract_hash);
 
     let is_operator_burn_mode: bool = support::query_stored_value(
         &builder,
@@ -1001,6 +1011,7 @@ fn should_safely_upgrade_with_operator_burn_mode() {
     assert_eq!(actual_event, expected_event, "Expected Migration event.");
 }
 
+#[ignore = "old wasms use `casper_add_contract_version` which was replaced with `casper_add_package_version`"]
 #[test]
 fn should_safely_upgrade_from_1_2_0_to_1_3_0() {
     //* starting total_token_supply 100u64
@@ -1020,6 +1031,7 @@ fn should_safely_upgrade_from_1_2_0_to_1_3_0() {
     );
 }
 
+#[ignore = "old wasms use `casper_add_contract_version` which was replaced with `casper_add_package_version`"]
 #[test]
 fn should_safely_upgrade_from_1_3_0_to_1_4_0() {
     //* starting total_token_supply 100u64
@@ -1039,6 +1051,7 @@ fn should_safely_upgrade_from_1_3_0_to_1_4_0() {
     );
 }
 
+#[ignore = "old wasms use `casper_add_contract_version` which was replaced with `casper_add_package_version`"]
 #[test]
 fn should_safely_upgrade_from_1_4_0_to_current_version() {
     //* starting total_token_supply 100u64
@@ -1058,9 +1071,10 @@ fn should_safely_upgrade_from_1_4_0_to_current_version() {
     );
 }
 
+#[ignore = "old wasms use `casper_add_contract_version` which was replaced with `casper_add_package_version`"]
 #[test]
 fn should_safely_upgrade_from_1_0_0_to_1_2_0_to_current_version() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -1078,7 +1092,7 @@ fn should_safely_upgrade_from_1_0_0_to_1_2_0_to_current_version() {
     builder.exec(install_request).expect_success().commit();
 
     let nft_contract_hash_1_0_0 = support::get_nft_contract_hash_1_0_0(&builder);
-    let nft_contract_key_1_0_0: Key = nft_contract_hash_1_0_0.into();
+    let nft_contract_key_1_0_0: Key = Key::contract_entity_key(nft_contract_hash_1_0_0);
 
     let upgrade_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -1104,8 +1118,8 @@ fn should_safely_upgrade_from_1_0_0_to_1_2_0_to_current_version() {
 
     assert_eq!(total_token_supply_post_upgrade, 50u64);
 
-    let nft_contract_hash_1_2_0: ContractHash = support::get_nft_contract_hash(&builder);
-    let nft_contract_key_1_2_0: Key = nft_contract_hash_1_2_0.into();
+    let nft_contract_hash_1_2_0 = support::get_nft_contract_hash(&builder);
+    let nft_contract_key_1_2_0: Key = Key::contract_entity_key(nft_contract_hash_1_2_0);
 
     let number_of_tokens_pre_migration = 3usize;
 
@@ -1143,7 +1157,7 @@ fn should_safely_upgrade_from_1_0_0_to_1_2_0_to_current_version() {
     builder.exec(upgrade_request).expect_success().commit();
 
     let nft_contract_hash = support::get_nft_contract_hash(&builder);
-    let nft_contract_key: Key = nft_contract_hash.into();
+    let nft_contract_key: Key = Key::contract_entity_key(nft_contract_hash);
 
     let number_of_tokens_at_upgrade = support::get_stored_value_from_global_state::<u64>(
         &builder,
@@ -1169,9 +1183,10 @@ fn should_safely_upgrade_from_1_0_0_to_1_2_0_to_current_version() {
     assert_eq!(actual_event, expected_event, "Expected Migration event.");
 }
 
+#[ignore = "old wasms use `casper_add_contract_version` which was replaced with `casper_add_package_version`"]
 #[test]
 fn should_safely_upgrade_from_1_0_0_to_1_3_0_to_current_version() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -1189,7 +1204,7 @@ fn should_safely_upgrade_from_1_0_0_to_1_3_0_to_current_version() {
     builder.exec(install_request).expect_success().commit();
 
     let nft_contract_hash_1_0_0 = support::get_nft_contract_hash_1_0_0(&builder);
-    let nft_contract_key_1_0_0: Key = nft_contract_hash_1_0_0.into();
+    let nft_contract_key_1_0_0: Key = Key::contract_entity_key(nft_contract_hash_1_0_0);
 
     let upgrade_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -1215,8 +1230,8 @@ fn should_safely_upgrade_from_1_0_0_to_1_3_0_to_current_version() {
 
     assert_eq!(total_token_supply_post_upgrade, 50u64);
 
-    let nft_contract_hash_1_3_0: ContractHash = support::get_nft_contract_hash(&builder);
-    let nft_contract_key_1_3_0: Key = nft_contract_hash_1_3_0.into();
+    let nft_contract_hash_1_3_0 = support::get_nft_contract_hash(&builder);
+    let nft_contract_key_1_3_0: Key = Key::contract_entity_key(nft_contract_hash_1_3_0);
 
     let number_of_tokens_pre_migration = 3usize;
 
@@ -1254,7 +1269,7 @@ fn should_safely_upgrade_from_1_0_0_to_1_3_0_to_current_version() {
     builder.exec(upgrade_request).expect_success().commit();
 
     let nft_contract_hash = support::get_nft_contract_hash(&builder);
-    let nft_contract_key: Key = nft_contract_hash.into();
+    let nft_contract_key: Key = Key::contract_entity_key(nft_contract_hash);
 
     let number_of_tokens_at_upgrade = support::get_stored_value_from_global_state::<u64>(
         &builder,
@@ -1280,9 +1295,10 @@ fn should_safely_upgrade_from_1_0_0_to_1_3_0_to_current_version() {
     assert_eq!(actual_event, expected_event, "Expected Migration event.");
 }
 
+#[ignore = "old wasms use `casper_add_contract_version` which was replaced with `casper_add_package_version`"]
 #[test]
 fn should_safely_upgrade_from_1_0_0_to_current_version() {
-    let mut builder = InMemoryWasmTestBuilder::default();
+    let mut builder = LmdbWasmTestBuilder::default();
     builder
         .run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST)
         .commit();
@@ -1334,7 +1350,7 @@ fn should_safely_upgrade_from_1_0_0_to_current_version() {
 
     builder.exec(upgrade_request).expect_success().commit();
 
-    let nft_contract_key: Key = support::get_nft_contract_hash(&builder).into();
+    let nft_contract_key: Key = Key::contract_entity_key(support::get_nft_contract_hash(&builder));
 
     let number_of_tokens_at_upgrade = support::get_stored_value_from_global_state::<u64>(
         &builder,

--- a/tests/src/utility/installer_request_builder.rs
+++ b/tests/src/utility/installer_request_builder.rs
@@ -1,7 +1,7 @@
 use casper_engine_test_support::ExecuteRequestBuilder;
-use casper_execution_engine::core::engine_state::ExecuteRequest;
+use casper_execution_engine::engine_state::ExecuteRequest;
 use casper_types::{
-    account::AccountHash, bytesrepr::Bytes, CLValue, ContractHash, Key, RuntimeArgs,
+    account::AccountHash, bytesrepr::Bytes, AddressableEntityHash, CLValue, Key, RuntimeArgs,
 };
 use contract::constants::{
     ARG_ACL_PACKAGE_MODE, ARG_ACL_WHITELIST, ARG_ADDITIONAL_REQUIRED_METADATA, ARG_ALLOW_MINTING,
@@ -173,7 +173,7 @@ impl InstallerRequestBuilder {
             nft_kind: CLValue::from_t(NFTKind::Physical as u8).unwrap(),
             holder_mode: CLValue::from_t(NFTHolderMode::Mixed as u8).unwrap(),
             whitelist_mode: CLValue::from_t(WhitelistMode::Unlocked as u8).unwrap(),
-            contract_whitelist: CLValue::from_t(Vec::<ContractHash>::new()).unwrap(),
+            contract_whitelist: CLValue::from_t(Vec::<AddressableEntityHash>::new()).unwrap(),
             acl_whitelist: CLValue::from_t(Vec::<Key>::new()).unwrap(),
             acl_package_mode: CLValue::from_t(false).unwrap(),
             package_operator_mode: CLValue::from_t(false).unwrap(),
@@ -267,7 +267,10 @@ impl InstallerRequestBuilder {
     }
 
     // Deprecated in 1.4
-    pub(crate) fn with_contract_whitelist(mut self, contract_whitelist: Vec<ContractHash>) -> Self {
+    pub(crate) fn with_contract_whitelist(
+        mut self,
+        contract_whitelist: Vec<AddressableEntityHash>,
+    ) -> Self {
         self.contract_whitelist = CLValue::from_t(contract_whitelist).unwrap();
         self
     }


### PR DESCRIPTION
Update CEP78 contract to use new API from casper-node `feat-2.0`.
Wire up native contract level messages in the CEP78 contract.

**DO NOT MERGE THIS PR**
Only putting this up for visibility.
`feat-2.0` of the node is under development and will likely change.