### PR TITLE
Enable entity and introduce key_as_account_or_contract_or_package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ setup-test: build-all-contracts
 .PHONY: test
 test: setup-test
 	cargo test -p tests --lib
+	cargo test -p tests --lib --features test-enable-addressable-entity
 
 .PHONY: clippy
 clippy:

--- a/contracts/contract/src/main.rs
+++ b/contracts/contract/src/main.rs
@@ -13,6 +13,7 @@ mod utils;
 
 extern crate alloc;
 
+use crate::utils::UpsertTransform;
 use alloc::{
     boxed::Box,
     collections::BTreeMap,
@@ -1055,13 +1056,14 @@ pub extern "C" fn approve() {
         ARG_OPERATOR, // Deprecated in favor of ARG_SPENDER
         NFTCoreError::InvalidApprovedAccountHash,
     ) {
-        Some(deprecated_operator) => deprecated_operator,
+        Some(deprecated_operator) => deprecated_operator.key_as_account_or_contract_or_package(),
         None => utils::get_named_arg_with_user_errors::<Key>(
             ARG_SPENDER,
             NFTCoreError::MissingSpenderAccountHash,
             NFTCoreError::InvalidSpenderAccountHash,
         )
-        .unwrap_or_revert(),
+        .unwrap_or_revert()
+        .key_as_account_or_contract_or_package(),
     };
 
     // If token owner or operator tries to approve itself that's probably a mistake and we revert.
@@ -1205,7 +1207,8 @@ pub extern "C" fn set_approval_for_all() {
         NFTCoreError::MissingOperator,
         NFTCoreError::InvalidOperator,
     )
-    .unwrap_or_revert();
+    .unwrap_or_revert()
+    .key_as_account_or_contract_or_package();
 
     // If caller tries to approve itself as operator that's probably a mistake and we revert.
     if caller == operator {
@@ -1231,14 +1234,16 @@ pub extern "C" fn is_approved_for_all() {
         NFTCoreError::MissingAccountHash,
         NFTCoreError::InvalidAccountHash,
     )
-    .unwrap_or_revert();
+    .unwrap_or_revert()
+    .key_as_account_or_contract_or_package();
 
     let operator = utils::get_named_arg_with_user_errors::<Key>(
         ARG_OPERATOR,
         NFTCoreError::MissingOperator,
         NFTCoreError::InvalidOperator,
     )
-    .unwrap_or_revert();
+    .unwrap_or_revert()
+    .key_as_account_or_contract_or_package();
 
     let owner_operator_item_key = utils::make_dictionary_item_key(&owner_key, &operator);
 
@@ -1293,7 +1298,8 @@ pub extern "C" fn transfer() {
         NFTCoreError::MissingAccountHash,
         NFTCoreError::InvalidAccountHash,
     )
-    .unwrap_or_revert();
+    .unwrap_or_revert()
+    .key_as_account_or_contract_or_package();
 
     if source_owner_key != owner {
         runtime::revert(NFTCoreError::InvalidTokenOwner);
@@ -1381,7 +1387,8 @@ pub extern "C" fn transfer() {
         NFTCoreError::MissingAccountHash,
         NFTCoreError::InvalidAccountHash,
     )
-    .unwrap_or_revert();
+    .unwrap_or_revert()
+    .key_as_account_or_contract_or_package();
 
     if NFTIdentifierMode::Hash == identifier_mode && runtime::get_key(OWNED_TOKENS).is_some() {
         if utils::should_migrate_token_hashes(source_owner_key) {
@@ -1392,8 +1399,6 @@ pub extern "C" fn transfer() {
             utils::migrate_token_hashes(target_owner_key)
         }
     }
-
-    let target_owner_item_key = utils::encode_dictionary_item_key(target_owner_key);
 
     // Updated token_owners dictionary. Revert if token_owner not found.
     utils::upsert_dictionary_value_from_key(
@@ -1425,6 +1430,8 @@ pub extern "C" fn transfer() {
         &source_owner_item_key,
         updated_from_account_balance,
     );
+
+    let target_owner_item_key = utils::encode_dictionary_item_key(target_owner_key);
 
     // Update the to_account balance
     let updated_to_account_balance =
@@ -1488,7 +1495,8 @@ pub extern "C" fn balance_of() {
         NFTCoreError::MissingAccountHash,
         NFTCoreError::InvalidAccountHash,
     )
-    .unwrap_or_revert();
+    .unwrap_or_revert()
+    .key_as_account_or_contract_or_package();
 
     let owner_key_item_string = utils::encode_dictionary_item_key(owner_key);
 
@@ -1994,6 +2002,7 @@ pub extern "C" fn register_owner() {
                     NFTCoreError::InvalidTokenOwner,
                 )
                 .unwrap_or_revert()
+                .key_as_account_or_contract_or_package()
             }
         };
 

--- a/contracts/contract/src/utils.rs
+++ b/contracts/contract/src/utils.rs
@@ -51,7 +51,31 @@ use hex::encode;
 // to ease the math around addressing newly minted tokens.
 pub const PAGE_SIZE: u64 = 1000;
 
-pub fn upsert_dictionary_value_from_key<T: CLTyped + FromBytes + ToBytes>(
+pub trait UpsertTransform: Sized {
+    fn key_as_account_or_contract_or_package(self) -> Self {
+        self
+    }
+}
+
+impl UpsertTransform for Key {
+    fn key_as_account_or_contract_or_package(self) -> Self {
+        key_as_account_or_contract_or_package(self)
+    }
+}
+
+impl UpsertTransform for Option<Key> {
+    fn key_as_account_or_contract_or_package(self) -> Self {
+        self.map(key_as_account_or_contract_or_package)
+    }
+}
+
+impl UpsertTransform for bool {}
+impl UpsertTransform for u32 {}
+impl UpsertTransform for u64 {}
+impl UpsertTransform for String {}
+impl UpsertTransform for () {}
+
+pub fn upsert_dictionary_value_from_key<T: CLTyped + FromBytes + ToBytes + UpsertTransform>(
     dictionary_name: &str,
     key: &str,
     value: T,
@@ -62,8 +86,10 @@ pub fn upsert_dictionary_value_from_key<T: CLTyped + FromBytes + ToBytes>(
         NFTCoreError::InvalidStorageUref,
     );
 
+    let transformed = value.key_as_account_or_contract_or_package();
+
     match dictionary_get::<T>(seed_uref, key) {
-        Ok(None | Some(_)) => dictionary_put(seed_uref, key, value),
+        Ok(None | Some(_)) => dictionary_put(seed_uref, key, transformed),
         Err(error) => revert(error),
     }
 }
@@ -262,13 +288,14 @@ fn get_key_with_user_errors(name: &str, missing: NFTCoreError, invalid: NFTCoreE
 
 pub fn get_immediate_caller() -> (Key, Option<Key>) {
     const ACCOUNT: u8 = 0;
+    const PACKAGE: u8 = 1;
     const CONTRACT_PACKAGE: u8 = 2;
     const ENTITY: u8 = 3;
     const CONTRACT: u8 = 4;
 
     let caller_info = casper_get_immediate_caller().unwrap_or_revert();
 
-    match caller_info.kind() {
+    let (caller, package): (Key, Option<Key>) = match caller_info.kind() {
         ACCOUNT => {
             let account_hash = caller_info
                 .get_field_by_index(ACCOUNT)
@@ -285,7 +312,13 @@ pub fn get_immediate_caller() -> (Key, Option<Key>) {
                 .to_t::<Option<EntityAddr>>()
                 .unwrap_or_revert()
                 .unwrap_or_revert_with(NFTCoreError::UnexpectedKeyVariant);
-            (Key::from(entity_addr), None)
+            let package_hash = caller_info
+                .get_field_by_index(PACKAGE)
+                .unwrap()
+                .to_t::<Option<PackageHash>>()
+                .unwrap_or_revert()
+                .unwrap_or_revert_with(NFTCoreError::UnexpectedKeyVariant);
+            (Key::from(entity_addr), Some(Key::from(package_hash)))
         }
         CONTRACT => {
             let contract_hash = caller_info
@@ -306,6 +339,29 @@ pub fn get_immediate_caller() -> (Key, Option<Key>) {
             )
         }
         _ => revert(NFTCoreError::UnexpectedKeyVariant),
+    };
+
+    let transformed_caller = key_as_account_or_contract_or_package(caller);
+    let transformed_package = package.map(key_as_account_or_contract_or_package);
+
+    (transformed_caller, transformed_package)
+}
+
+pub fn key_as_account_or_contract_or_package(key: Key) -> Key {
+    match key {
+        Key::AddressableEntity(entity_addr) => {
+            if entity_addr.is_account() {
+                let account_hash = AccountHash::new(entity_addr.value());
+                Key::Account(account_hash)
+            } else {
+                Key::Hash(entity_addr.value())
+            }
+        }
+        // Manage PackageHash from `get_immediate_caller` ENTITY case
+        Key::SmartContract(package_addr) => Key::Hash(package_addr),
+        // Legacy cases Account + ContractPackageHash from `get_immediate_caller` ACCOUNT + CONTRACT
+        // cases
+        legacy => legacy,
     }
 }
 

--- a/contracts/contract/src/utils.rs
+++ b/contracts/contract/src/utils.rs
@@ -51,6 +51,13 @@ use hex::encode;
 // to ease the math around addressing newly minted tokens.
 pub const PAGE_SIZE: u64 = 1000;
 
+/// Trait for transforming values before inserting them into a dictionary.
+///
+/// For most types, the default implementation does nothing.
+/// For `Key` and `Option<Key>`, it normalizes the key into a canonical form:
+/// - `AddressableEntity` → `Account` or `Hash`
+/// - `SmartContract` → `Hash`
+/// This ensures consistency when storing keys in the contract storage.
 pub trait UpsertTransform: Sized {
     fn key_as_account_or_contract_or_package(self) -> Self {
         self
@@ -69,12 +76,27 @@ impl UpsertTransform for Option<Key> {
     }
 }
 
+// Default implementations for other common types
 impl UpsertTransform for bool {}
 impl UpsertTransform for u32 {}
 impl UpsertTransform for u64 {}
 impl UpsertTransform for String {}
 impl UpsertTransform for () {}
 
+/// Inserts or updates a dictionary value, applying any necessary transformations
+/// (e.g., normalizing `Key`s) before storage.
+///
+/// # Arguments
+/// * `dictionary_name` - The name of the on-chain dictionary to update.
+/// * `key` - The dictionary key under which the value should be stored.
+/// * `value` - The value to store. Can be any type implementing `CLTyped + FromBytes + ToBytes +
+///   UpsertTransform`.
+///
+/// # Behavior
+/// 1. Retrieves the URef for the dictionary, reverting if missing or invalid.
+/// 2. Transforms the value using `UpsertTransform::key_as_account_or_contract_or_package`.
+/// 3. Stores the transformed value in the dictionary, overwriting any existing value.
+/// 4. Reverts if `dictionary_get` fails.
 pub fn upsert_dictionary_value_from_key<T: CLTyped + FromBytes + ToBytes + UpsertTransform>(
     dictionary_name: &str,
     key: &str,
@@ -286,6 +308,21 @@ fn get_key_with_user_errors(name: &str, missing: NFTCoreError, invalid: NFTCoreE
     deserialize(key_bytes).unwrap_or_revert_with(invalid)
 }
 
+/// Retrieves the immediate caller of the current contract execution context as a [`Key`]
+/// and optionally a package [`Key`], suitable for CEP-78 contracts.
+///
+/// This function abstracts over the different kinds of entities that may invoke a contract:
+/// legacy accounts, legacy contract packages, or new-style entities.
+///
+/// # Behavior
+///
+/// * **ACCOUNT (legacy or new entity account)** Returns a `Key::Account` wrapping the
+///   `AccountHash`, package is `None`.
+/// * **CONTRACT (legacy contract package)** Returns a `Key::Hash` wrapping the
+///   `ContractPackageHash`, package is `Some(Key::from(ContractPackageHash))`.
+/// * **ENTITY (new entity)** Returns a `Key::Hash` wrapping the `EntityAddr`, package is
+///   `Some(Key::from(PackageHash))`.
+/// * **Other / unexpected kinds** Reverts with [`NFTCoreError::UnexpectedKeyVariant`].
 pub fn get_immediate_caller() -> (Key, Option<Key>) {
     const ACCOUNT: u8 = 0;
     const PACKAGE: u8 = 1;
@@ -341,12 +378,36 @@ pub fn get_immediate_caller() -> (Key, Option<Key>) {
         _ => revert(NFTCoreError::UnexpectedKeyVariant),
     };
 
+    // Transform the caller Key to a legacy-compatible form (Account or Hash) for consistent
+    // on-chain usage. Apply the same transformation to the optional package Key, returning
+    // (caller, package) ready for CEP-78 logic.
+    // ⚠️ Strongly recommended: apply `key_as_account_or_contract_or_package()` to any `Key`
+    // retrieved from named arguments before comparing with the caller. This ensures consistent
+    // normalization between user input and immediate caller, preventing mismatches.
     let transformed_caller = key_as_account_or_contract_or_package(caller);
     let transformed_package = package.map(key_as_account_or_contract_or_package);
-
     (transformed_caller, transformed_package)
 }
 
+/// Converts a new-style [`Key`] returned by [`get_immediate_caller`] into a legacy-compatible
+/// [`Key`].
+///
+/// This function ensures backward compatibility with legacy expectations,
+/// where only `Account` or `Hash` were used for access control.
+///
+/// # Behavior
+///
+/// * **`Key::AddressableEntity`**
+///   - If the entity is an **account**, returns `Key::Account`.
+///   - If the entity is not an account (e.g., smart contract or system entity), returns
+///     `Key::Hash`.
+/// * **`Key::SmartContract`** Converts directly into a legacy `Key::Hash` using the `PackageHash`.
+/// * **Other legacy keys** (`Key::Account`, `Key::Hash`) Returned unchanged.
+///
+/// # Notes
+///
+/// - This function is mostly used in CEP-78 contracts for dictionary keys, ownership lookups, and
+///   other storage/access operations.
 pub fn key_as_account_or_contract_or_package(key: Key) -> Key {
     match key {
         Key::AddressableEntity(entity_addr) => {

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -18,3 +18,6 @@ blake2 = { version = "0.9.2", default-features = false }
 base16 = { version = "*", default-features = false }
 rand = "*"
 sha256 = "*"
+
+[features]
+test-enable-addressable-entity = []

--- a/tests/src/acl.rs
+++ b/tests/src/acl.rs
@@ -45,7 +45,6 @@ fn should_install_with_acl_whitelist() {
         .expect_success()
         .commit();
 
-    // TODO check
     let minting_contract_hash: ContractHash = get_minting_contract_hash(&builder).into();
     let contract_whitelist = vec![Key::from(minting_contract_hash)];
 
@@ -89,7 +88,6 @@ fn should_install_with_deprecated_contract_whitelist() {
         .expect_success()
         .commit();
 
-    // TODO check
     let minting_contract_hash: ContractHash = get_minting_contract_hash(&builder).into();
     let contract_whitelist = vec![minting_contract_hash];
 
@@ -333,7 +331,6 @@ fn should_allow_whitelisted_contract_to_mint() {
         .expect_success()
         .commit();
 
-    // TODO check
     let minting_contract_hash: ContractHash = get_minting_contract_hash(&builder).into();
     let contract_whitelist = vec![Key::from(minting_contract_hash)];
 
@@ -661,7 +658,6 @@ fn should_disallow_unlisted_account_from_minting_with_mixed_account_contract() {
         .expect_success()
         .commit();
 
-    // TODO check
     let minting_contract_hash: ContractHash = get_minting_contract_hash(&builder).into();
     let mixed_whitelist = vec![
         Key::from(minting_contract_hash),
@@ -735,7 +731,6 @@ fn should_disallow_listed_account_from_minting_with_nftholder_contract() {
         .expect_success()
         .commit();
 
-    // TODO check
     let minting_contract_hash: ContractHash = get_minting_contract_hash(&builder).into();
     let mixed_whitelist = vec![
         Key::from(minting_contract_hash),

--- a/tests/src/burn.rs
+++ b/tests/src/burn.rs
@@ -323,7 +323,6 @@ fn should_allow_contract_to_burn_token() {
         .expect_success()
         .commit();
 
-    // TODO check
     let minting_contract_hash: ContractHash = get_minting_contract_hash(&builder).into();
     let contract_whitelist = vec![Key::from(minting_contract_hash)];
 

--- a/tests/src/events.rs
+++ b/tests/src/events.rs
@@ -2,7 +2,10 @@ use std::collections::BTreeMap;
 
 use casper_engine_test_support::{ExecuteRequestBuilder, DEFAULT_ACCOUNT_ADDR};
 use casper_event_standard::EVENTS_DICT;
-use casper_types::{addressable_entity::EntityKindTag, runtime_args, AddressableEntityHash, Key};
+use casper_types::{
+    account::AccountHash, addressable_entity::EntityKindTag, runtime_args, AddressableEntityHash,
+    Key,
+};
 
 use cep78::{
     constants::{
@@ -129,10 +132,13 @@ fn should_record_cep47_dictionary_style_transfer_token_event_in_hash_identifier_
     let token_hash: String =
         base16::encode_lower(&support::create_blake2b_hash(TEST_PRETTY_721_META_DATA));
 
-    let owner = Key::addressable_entity_key(
-        EntityKindTag::Account,
-        AddressableEntityHash::new([3u8; 32]),
-    );
+    let owner = match builder.chainspec().core_config.enable_addressable_entity {
+        true => Key::addressable_entity_key(
+            EntityKindTag::Account,
+            AddressableEntityHash::new([3u8; 32]),
+        ),
+        false => Key::Account(AccountHash::new([3u8; 32])),
+    };
 
     let register_request = ExecuteRequestBuilder::contract_call_by_hash(
         *DEFAULT_ACCOUNT_ADDR,
@@ -178,9 +184,12 @@ fn should_record_cep47_dictionary_style_transfer_token_event_in_hash_identifier_
 
     let mut expected_event: BTreeMap<String, String> = BTreeMap::new();
 
+    // Event is always as legacy Key for recipient
+    let recipient = Key::Account(AccountHash::new([3u8; 32]));
+
     expected_event.insert(EVENT_TYPE.to_string(), "Transfer".to_string());
     expected_event.insert(PREFIX_HASH_KEY_NAME.to_string(), package);
-    expected_event.insert(RECIPIENT.to_string(), owner.to_string());
+    expected_event.insert(RECIPIENT.to_string(), recipient.to_string());
     expected_event.insert(SENDER.to_string(), DEFAULT_ACCOUNT_KEY.to_string());
     expected_event.insert(
         TOKEN_ID.to_string(),
@@ -479,10 +488,13 @@ fn should_cep47_dictionary_style_approve_event_in_hash_identifier_mode() {
     let token_hash: String =
         base16::encode_lower(&support::create_blake2b_hash(TEST_PRETTY_721_META_DATA));
 
-    let spender = Key::addressable_entity_key(
-        EntityKindTag::Account,
-        AddressableEntityHash::new([7u8; 32]),
-    );
+    let spender = match builder.chainspec().core_config.enable_addressable_entity {
+        true => Key::addressable_entity_key(
+            EntityKindTag::Account,
+            AddressableEntityHash::new([7u8; 32]),
+        ),
+        false => Key::Account(AccountHash::new([7u8; 32])),
+    };
 
     let approve_request = ExecuteRequestBuilder::contract_call_by_hash(
         *DEFAULT_ACCOUNT_ADDR,
@@ -504,7 +516,10 @@ fn should_cep47_dictionary_style_approve_event_in_hash_identifier_mode() {
         &token_hash,
     );
 
-    assert_eq!(maybe_approved_spender, Some(spender));
+    assert_eq!(
+        maybe_approved_spender.map(|key| key.into_entity_hash()),
+        Some(spender.into_entity_hash())
+    );
 
     let event = get_dictionary_value_from_key::<BTreeMap<String, String>>(
         &builder,
@@ -521,6 +536,10 @@ fn should_cep47_dictionary_style_approve_event_in_hash_identifier_mode() {
         nft_contract_key,
         &format!("{PREFIX_CEP78}_{collection_name}"),
     );
+
+    // Event is always as legacy Key for spender
+    let spender = Key::Account(AccountHash::new([7u8; 32]));
+
     let mut expected_event: BTreeMap<String, String> = BTreeMap::new();
     expected_event.insert(EVENT_TYPE.to_string(), "Approve".to_string());
     expected_event.insert(PREFIX_HASH_KEY_NAME.to_string(), package);

--- a/tests/src/installer.rs
+++ b/tests/src/installer.rs
@@ -423,8 +423,6 @@ fn should_prevent_double_install_but_upgrade_instead() {
 
     let first_nft_contract_package_hash = get_nft_contract_package_hash_cep78(&builder);
 
-    dbg!(first_nft_contract_package_hash);
-
     let install_request = InstallerRequestBuilder::new(*DEFAULT_ACCOUNT_ADDR, NFT_CONTRACT_WASM)
         .with_collection_name(NFT_TEST_COLLECTION.to_string())
         .with_collection_symbol(NFT_TEST_SYMBOL.to_string())
@@ -440,6 +438,4 @@ fn should_prevent_double_install_but_upgrade_instead() {
         first_nft_contract_package_hash,
         last_nft_contract_package_hash
     );
-
-    dbg!(last_nft_contract_package_hash);
 }

--- a/tests/src/metadata.rs
+++ b/tests/src/metadata.rs
@@ -400,7 +400,6 @@ fn should_get_metadata_using_token_id() {
         .expect_success()
         .commit();
 
-    // TODO check
     let minting_contract_hash: ContractHash = get_minting_contract_hash(&builder).into();
     let contract_whitelist = vec![Key::from(minting_contract_hash)];
 
@@ -485,7 +484,6 @@ fn should_get_metadata_using_token_metadata_hash() {
         .expect_success()
         .commit();
 
-    // TODO check
     let minting_contract_hash: ContractHash = get_minting_contract_hash(&builder).into();
     let contract_whitelist = vec![Key::from(minting_contract_hash)];
 
@@ -574,7 +572,6 @@ fn should_revert_minting_token_metadata_hash_twice() {
         .expect_success()
         .commit();
 
-    // TODO check
     let minting_contract_hash: ContractHash = get_minting_contract_hash(&builder).into();
     let contract_whitelist = vec![Key::from(minting_contract_hash)];
 
@@ -676,7 +673,6 @@ fn should_get_metadata_using_custom_token_hash() {
         .expect_success()
         .commit();
 
-    // TODO check
     let minting_contract_hash: ContractHash = get_minting_contract_hash(&builder).into();
     let contract_whitelist = vec![Key::from(minting_contract_hash)];
 
@@ -763,7 +759,6 @@ fn should_revert_minting_custom_token_hash_identifier_twice() {
         .expect_success()
         .commit();
 
-    // TODO check
     let minting_contract_hash: ContractHash = get_minting_contract_hash(&builder).into();
     let contract_whitelist = vec![Key::from(minting_contract_hash)];
 

--- a/tests/src/transfer.rs
+++ b/tests/src/transfer.rs
@@ -993,7 +993,6 @@ fn should_transfer_between_contract_to_account() {
         .expect_success()
         .commit();
 
-    // TODO check
     let minting_contract_hash: ContractHash = get_minting_contract_hash(&builder).into();
     let contract_whitelist = vec![Key::from(minting_contract_hash)];
 
@@ -1048,7 +1047,10 @@ fn should_transfer_between_contract_to_account() {
         &token_id.to_string(),
     );
 
-    assert_eq!(minting_contract_key, actual_token_owner);
+    assert_eq!(
+        minting_contract_key.into_entity_hash(),
+        actual_token_owner.into_entity_hash()
+    );
 
     let register_request = ExecuteRequestBuilder::contract_call_by_hash(
         *DEFAULT_ACCOUNT_ADDR,

--- a/tests/src/utility/support.rs
+++ b/tests/src/utility/support.rs
@@ -15,8 +15,9 @@ use blake2::{
     VarBlake2b,
 };
 use casper_engine_test_support::{
-    utils::create_run_genesis_request, ChainspecConfig, ExecuteRequestBuilder, LmdbWasmTestBuilder,
-    DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_PUBLIC_KEY,
+    utils::{create_run_genesis_request, create_run_genesis_request_with_chainspec_config},
+    ChainspecConfig, ExecuteRequestBuilder, LmdbWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
+    DEFAULT_ACCOUNT_PUBLIC_KEY,
 };
 use casper_execution_engine::{engine_state::Error as EngineStateError, execution::ExecError};
 use casper_types::{
@@ -33,32 +34,41 @@ use serde::{Deserialize, Serialize};
 use sha256::digest;
 use std::fmt::Debug;
 
+pub(crate) fn get_enable_addressable_entity() -> bool {
+    cfg!(feature = "test-enable-addressable-entity")
+}
+
 pub(crate) fn genesis() -> LmdbWasmTestBuilder {
-    let mut builder = LmdbWasmTestBuilder::default();
-    // TODO Set enable_addressable_entity as param
-    builder.with_chainspec(ChainspecConfig::default().with_enable_addressable_entity(false));
-    builder.run_genesis(create_run_genesis_request(vec![
-        GenesisAccount::Account {
-            public_key: DEFAULT_ACCOUNT_PUBLIC_KEY.clone(),
-            balance: Motes::new(U512::from(5_000_000_000_000_u64)),
-            validator: None,
-        },
-        GenesisAccount::Account {
-            public_key: ACCOUNT_1_PUBLIC_KEY.clone(),
-            balance: Motes::new(U512::from(5_000_000_000_000_u64)),
-            validator: None,
-        },
-        GenesisAccount::Account {
-            public_key: ACCOUNT_2_PUBLIC_KEY.clone(),
-            balance: Motes::new(U512::from(5_000_000_000_000_u64)),
-            validator: None,
-        },
-        GenesisAccount::Account {
-            public_key: ACCOUNT_3_PUBLIC_KEY.clone(),
-            balance: Motes::new(U512::from(5_000_000_000_000_u64)),
-            validator: None,
-        },
-    ]));
+    let chainspec =
+        ChainspecConfig::default().with_enable_addressable_entity(get_enable_addressable_entity());
+
+    let mut builder = LmdbWasmTestBuilder::new_temporary_with_config(chainspec.clone());
+
+    builder.run_genesis(create_run_genesis_request_with_chainspec_config(
+        vec![
+            GenesisAccount::Account {
+                public_key: DEFAULT_ACCOUNT_PUBLIC_KEY.clone(),
+                balance: Motes::new(U512::from(5_000_000_000_000_u64)),
+                validator: None,
+            },
+            GenesisAccount::Account {
+                public_key: ACCOUNT_1_PUBLIC_KEY.clone(),
+                balance: Motes::new(U512::from(5_000_000_000_000_u64)),
+                validator: None,
+            },
+            GenesisAccount::Account {
+                public_key: ACCOUNT_2_PUBLIC_KEY.clone(),
+                balance: Motes::new(U512::from(5_000_000_000_000_u64)),
+                validator: None,
+            },
+            GenesisAccount::Account {
+                public_key: ACCOUNT_3_PUBLIC_KEY.clone(),
+                balance: Motes::new(U512::from(5_000_000_000_000_u64)),
+                validator: None,
+            },
+        ],
+        chainspec,
+    ));
     builder
 }
 
@@ -77,9 +87,10 @@ pub(crate) fn get_nft_contract_hash(builder: &LmdbWasmTestBuilder) -> Addressabl
 
 pub(crate) fn get_nft_contract_hash_key(builder: &LmdbWasmTestBuilder) -> Key {
     let nft_contract_hash: ContractHash = get_nft_contract_hash(builder).into();
-    // With entities enabled
-    //  let nft_contract_key: Key = Key::contract_entity_key(nft_contract_hash.into()); // As AddressableEntityHash
-    Key::Hash(nft_contract_hash.value()) // As Key::Hash
+    match builder.chainspec().core_config.enable_addressable_entity {
+        true => Key::contract_entity_key(nft_contract_hash.into()),
+        false => Key::Hash(nft_contract_hash.value()),
+    }
 }
 
 pub(crate) fn get_nft_contract_package_hash(builder: &LmdbWasmTestBuilder) -> ContractPackageHash {
@@ -123,9 +134,10 @@ pub(crate) fn get_minting_contract_hash(builder: &LmdbWasmTestBuilder) -> Addres
 
 pub(crate) fn get_minting_contract_hash_key(builder: &LmdbWasmTestBuilder) -> Key {
     let minting_contract_hash: ContractHash = get_minting_contract_hash(builder).into();
-    // With entities enabled
-    // let minting_contract_key: Key = Key::contract_entity_key(minting_contract_hash.into());
-    Key::Hash(minting_contract_hash.value())
+    match builder.chainspec().core_config.enable_addressable_entity {
+        true => Key::contract_entity_key(minting_contract_hash.into()),
+        false => Key::Hash(minting_contract_hash.value()),
+    }
 }
 
 pub(crate) fn get_minting_contract_package_hash(builder: &LmdbWasmTestBuilder) -> PackageHash {


### PR DESCRIPTION
Updated get_immediate_caller and Add key_as_account_or_contract_or_package Key conversion

maintains CEP-18 compatibility, and standardizes caller Key for balances and allowances dictionaries.

Updated get_immediate_caller to clearly map different caller kinds (ACCOUNT, CONTRACT, ENTITY) to a Key, handling:

Legacy accounts + New entities account → AccountHash

Legacy contract packages → ContractPackageHash

New entities (not account)→ PackageHash

Introduced key_as_account_or_contract_or_package helper to convert new-style Key returned by get_immediate_caller into a compatible Key (AccountHash / Hash), ensuring backward compatibility. Storage keeps Key (AccountHash / Hash).

Documented behavior

Testing note: In tests enabling Addressable entities in test builder is depending on added feature test-enable-addressable-entity . Test are now run with or without addressable-entity